### PR TITLE
OHttpContentParser and OHttpContentSerializer should be package-private

### DIFF
--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpContentParser.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpContentParser.java
@@ -31,7 +31,7 @@ import static io.netty.handler.codec.ByteToMessageDecoder.MERGE_CUMULATOR;
  * Parser that parses {@link ByteBuf}s coming from the content of a OHTTP-encoded message
  * into {@link HttpObject}s.
  */
-public abstract class OHttpContentParser {
+abstract class OHttpContentParser {
 
     private final OHttpChunkFramer<HttpObject> framer;
 
@@ -135,6 +135,5 @@ public abstract class OHttpContentParser {
             binaryHttpCumulation.release();
             binaryHttpCumulation = Unpooled.EMPTY_BUFFER;
         }
-
     }
 }

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpContentSerializer.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpContentSerializer.java
@@ -24,7 +24,7 @@ import io.netty.handler.codec.http.LastHttpContent;
 /**
  * Serializer that serializes {@link HttpObject}s to {@link ByteBuf} that can be used as OHTTP message content.
  */
-public abstract class OHttpContentSerializer {
+abstract class OHttpContentSerializer {
 
     private final OHttpChunkFramer<HttpObject> framer;
 


### PR DESCRIPTION
Motivation:

The OHttpContentParser and OHttpContentSerializer are not public API and so should be package-private

Modifications:

Remove public from classes

Result:

Hide none public API