### PR TITLE
Reduce memory copies by directly writing / reading ByteBuf

### DIFF
--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCiphersuite.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCiphersuite.java
@@ -73,23 +73,11 @@ public final class OHttpCiphersuite {
         return aead;
     }
 
-    private void encode(ByteBuf out) {
+    void encode(ByteBuf out) {
         out.writeByte(keyId);
         out.writeShort(kem.id());
         out.writeShort(kdf.id());
         out.writeShort(aead.id());
-    }
-
-    byte[] createHeader() {
-        byte[] ret = new byte[7];
-        ByteBuf buf = Unpooled.wrappedBuffer(ret);
-        try {
-            buf.writerIndex(0);
-            encode(buf);
-            return ret;
-        } finally {
-            buf.release();
-        }
     }
 
     /*

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpClientCodec.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpClientCodec.java
@@ -189,12 +189,12 @@ public final class OHttpClientCodec extends MessageToMessageCodec<HttpObject, Ht
     }
 
     @Override
-    public final boolean isSharable() {
+    public boolean isSharable() {
         return false;
     }
 
     @Override
-    protected final void decode(ChannelHandlerContext ctx, HttpObject msg, List<Object> out) {
+    protected void decode(ChannelHandlerContext ctx, HttpObject msg, List<Object> out) {
         if (destroyed) {
             throw new IllegalStateException("Already destroyed");
         }
@@ -234,7 +234,7 @@ public final class OHttpClientCodec extends MessageToMessageCodec<HttpObject, Ht
     }
 
     @Override
-    protected final void encode(ChannelHandlerContext ctx, HttpObject msg, List<Object> out) {
+    protected void encode(ChannelHandlerContext ctx, HttpObject msg, List<Object> out) {
         try {
             if (msg instanceof HttpRequest) {
                 HttpRequest innerRequest = (HttpRequest) msg;
@@ -288,7 +288,7 @@ public final class OHttpClientCodec extends MessageToMessageCodec<HttpObject, Ht
     }
 
     @Override
-    public final void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+    public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
         if (!destroyed) {
             destroyed = true;
             cumulationBuffer.release();
@@ -321,13 +321,7 @@ public final class OHttpClientCodec extends MessageToMessageCodec<HttpObject, Ht
 
         @Override
         public boolean decodePrefix(ByteBuf in) {
-            if (in.readableBytes() < sender.ciphersuite().responseNonceLength()) {
-                return false;
-            }
-            byte[] responseNonce = new byte[sender.ciphersuite().responseNonceLength()];
-            in.readBytes(responseNonce);
-            sender.setResponseNonce(responseNonce);
-            return true;
+            return sender.readResponseNonce(in);
         }
 
         @Override
@@ -338,7 +332,7 @@ public final class OHttpClientCodec extends MessageToMessageCodec<HttpObject, Ht
 
         @Override
         public void encodePrefixNow(ByteBuf out) {
-            out.writeBytes(sender.header());
+            sender.writeHeader(out);
         }
 
         @Override

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCryptoReceiver.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCryptoReceiver.java
@@ -111,8 +111,8 @@ public final class OHttpCryptoReceiver {
         this.aead = builder.ciphersuite.createResponseAead(builder.encryption, this.context, enc, this.responseNonce, configuration);
     }
 
-    public byte[] responseNonce() {
-        return this.responseNonce.clone();
+    public void writeResponseNonce(ByteBuf out) {
+        out.writeBytes(responseNonce);
     }
 
     public void decrypt(ByteBuf message, int messageLength, boolean isFinal, ByteBuf out) throws CryptoException {

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpKey.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpKey.java
@@ -37,7 +37,7 @@ public abstract class OHttpKey {
     OHttpKey(byte id, KEM kem, List<Cipher> ciphers) {
         this.id = id;
         this.kem = kem;
-        this.ciphers = Collections.unmodifiableList(checkNotNull(ciphers, "encryptionCiphers"));
+        this.ciphers = Collections.unmodifiableList(checkNotNull(ciphers, "ciphers"));
     }
 
     public byte id() {

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
@@ -279,7 +279,7 @@ public class OHttpServerCodec extends MessageToMessageCodec<HttpObject, HttpObje
         @Override
         public void encodePrefixNow(ByteBuf out) throws CryptoException {
             checkPrefixDecoded();
-            out.writeBytes(receiver.responseNonce());
+            receiver.writeResponseNonce(out);
         }
 
         @Override

--- a/codec-ohttp/src/test/java/io/netty/incubator/codec/ohttp/OHttpCryptoTest.java
+++ b/codec-ohttp/src/test/java/io/netty/incubator/codec/ohttp/OHttpCryptoTest.java
@@ -105,7 +105,8 @@ public class OHttpCryptoTest {
         ByteBuf decodedResponse = Unpooled.buffer();
         try {
             sender.encrypt(Unpooled.wrappedBuffer(request), request.length, true, encrypted);
-            encodedRequest.writeBytes(sender.header()).writeBytes(encrypted);
+            sender.writeHeader(encodedRequest);
+            encodedRequest.writeBytes(encrypted);
 
             assertEquals(
                     "010020000100014b28f881333e7c164ffc499ad9796f877f4e1051ee6d31bad19dec96c208b4726374e469135906992"
@@ -133,15 +134,14 @@ public class OHttpCryptoTest {
             // Receiver encodes response
 
             receiver.encrypt(responseBuffer, response.length, true, enc);
-            encodedResponse.writeBytes(receiver.responseNonce()).writeBytes(enc);
+            receiver.writeResponseNonce(encodedResponse);
+            encodedResponse.writeBytes(enc);
             assertEquals("c789e7151fcba46158ca84b04464910d86f9013e404feea014e7be4a441f234f857fbd", ByteBufUtil.hexDump(encodedResponse));
 
             // Sender decodes response
 
             encodedResponse.readerIndex(0);
-            byte[] responseNonce = new byte[receiverCiphersuite.responseNonceLength()];
-            encodedResponse.readBytes(responseNonce);
-            sender.setResponseNonce(responseNonce);
+            sender.readResponseNonce(encodedResponse);
 
             sender.decrypt(encodedResponse, encodedResponse.readableBytes(), true, decodedResponse);
             assertEquals(responseBuffer.readerIndex(0), decodedResponse);


### PR DESCRIPTION
Motivation:

We should just directly pass in ByteBuf instances to reduce memory copies when doing crypto.

Modifications:

Adjust APIs to use ByteBuf directly.

Result:

Reduce memory copies and also make API more consistent of the sender and receiver