### PR TITLE
Rename method to be more consistent

### DIFF
--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpClientCodec.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpClientCodec.java
@@ -331,7 +331,7 @@ public final class OHttpClientCodec extends MessageToMessageCodec<HttpObject, Ht
         }
 
         @Override
-        public void encodePrefixNow(ByteBuf out) {
+        public void encodePrefix(ByteBuf out) {
             sender.writeHeader(out);
         }
 

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpRequestResponseContext.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpRequestResponseContext.java
@@ -71,7 +71,7 @@ abstract class OHttpRequestResponseContext {
      * @param out buffer to write the bytes.
      * @throws CryptoException if the prefix cannot be encoded.
      */
-    protected abstract void encodePrefixNow(ByteBuf out) throws CryptoException;
+    protected abstract void encodePrefix(ByteBuf out) throws CryptoException;
 
     private final class ContentEncoder implements OHttpChunkFramer.Encoder<HttpObject> {
 
@@ -101,7 +101,7 @@ abstract class OHttpRequestResponseContext {
             if (encodedPrefix) {
                 throw new IllegalStateException("Prefix already encoded");
             }
-            encodePrefixNow(out);
+            OHttpRequestResponseContext.this.encodePrefix(out);
             encodedPrefix = true;
         }
     }

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
@@ -277,7 +277,7 @@ public class OHttpServerCodec extends MessageToMessageCodec<HttpObject, HttpObje
 
 
         @Override
-        public void encodePrefixNow(ByteBuf out) throws CryptoException {
+        public void encodePrefix(ByteBuf out) throws CryptoException {
             checkPrefixDecoded();
             receiver.writeResponseNonce(out);
         }


### PR DESCRIPTION
Motivation:

We should rename the method and remove the "Now" suffix to be more consistent with other methods.

Modifications:

Rename method

Result:

Cleanup