### PR TITLE
Response must use 4xx status code when sent because of decoding error

### DIFF
--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
@@ -151,7 +151,7 @@ public class OHttpServerCodec extends MessageToMessageCodec<HttpObject, HttpObje
                 out.add(ReferenceCountUtil.retain(msg));
             }
         } catch (Exception e) {
-            throw new OHttpServerDecodingException("failed to decrypt bytes", e);
+            throw new OHttpServerDecodingException("failed to decode bytes", e);
         }
     }
 

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
@@ -151,7 +151,7 @@ public class OHttpServerCodec extends MessageToMessageCodec<HttpObject, HttpObje
                 out.add(ReferenceCountUtil.retain(msg));
             }
         } catch (Exception e) {
-            throw new OHttpServerDecodingException("failed to decode bytes", e);
+            throw new OHttpServerDecoderException("failed to decode bytes", e);
         }
     }
 
@@ -163,7 +163,7 @@ public class OHttpServerCodec extends MessageToMessageCodec<HttpObject, HttpObje
 
             // Respond with 4xx status code in case of unable to decode message:
             // See https://www.ietf.org/archive/id/draft-ietf-ohai-ohttp-10.html#section-5.2
-            HttpResponseStatus status = cause instanceof OHttpServerDecodingException ?
+            HttpResponseStatus status = cause instanceof OHttpServerDecoderException ?
                     HttpResponseStatus.BAD_REQUEST : HttpResponseStatus.INTERNAL_SERVER_ERROR;
             FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, status);
             HttpUtil.setKeepAlive(response, false);
@@ -233,8 +233,8 @@ public class OHttpServerCodec extends MessageToMessageCodec<HttpObject, HttpObje
         }
     }
 
-    private static final class OHttpServerDecodingException extends DecoderException {
-        OHttpServerDecodingException(String msg, Throwable cause) {
+    private static final class OHttpServerDecoderException extends DecoderException {
+        OHttpServerDecoderException(String msg, Throwable cause) {
             super(msg, cause);
         }
     }


### PR DESCRIPTION
Motivation:

A 4xx status code must be used when sending a response caused because of an decoding error: https://www.ietf.org/archive/id/draft-ietf-ohai-ohttp-10.html#section-5.2

Modifications:

Use a 4xx status code when exception is caused because of decoding

Result:

Follow the spec