### PR TITLE
CryptoOperations API should use ByteBuf

### DIFF
--- a/codec-ohttp-hpke/pom.xml
+++ b/codec-ohttp-hpke/pom.xml
@@ -59,6 +59,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
         </dependency>

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/CryptoOperations.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/CryptoOperations.java
@@ -15,6 +15,8 @@
  */
 package io.netty.incubator.codec.hpke;
 
+import io.netty.buffer.ByteBuf;
+
 import java.nio.ByteBuffer;
 
 /**
@@ -28,10 +30,10 @@ public interface CryptoOperations {
      *
      * @param aad   the AAD buffer
      * @param pt    the data to encrypt.
-     * @return      the encrypted data.
+     * @param out   the buffer for writing into
      * @throws      CryptoException in case of an error.
      */
-    ByteBuffer seal(ByteBuffer aad, ByteBuffer pt) throws CryptoException;
+    void seal(ByteBuf aad, ByteBuf pt, ByteBuf out) throws CryptoException;
 
     /**
      * Authenticate and decrypt data. The {@link ByteBuffer#position()} will be increased by the amount of
@@ -39,8 +41,8 @@ public interface CryptoOperations {
      *
      * @param aad   the AAD buffer
      * @param ct    the data to decrypt
-     * @return      the decrypted data.
+     * @param out   the buffer for writing into.
      * @throws      CryptoException in case of an error.
      */
-    ByteBuffer open(ByteBuffer aad, ByteBuffer ct) throws CryptoException;
+    void open(ByteBuf aad, ByteBuf ct, ByteBuf out) throws CryptoException;
 }

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleAEADCryptoOperations.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleAEADCryptoOperations.java
@@ -15,6 +15,7 @@
  */
 package io.netty.incubator.codec.hpke.bouncycastle;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.incubator.codec.hpke.CryptoException;
 import io.netty.incubator.codec.hpke.CryptoOperations;
 import org.bouncycastle.crypto.InvalidCipherTextException;
@@ -45,12 +46,12 @@ final class BouncyCastleAEADCryptoOperations implements CryptoOperations {
     }
 
     @Override
-    public ByteBuffer seal(ByteBuffer aad, ByteBuffer pt) throws CryptoException {
-        return seal.execute(aad, pt);
+    public void seal(ByteBuf aad, ByteBuf pt, ByteBuf out) throws CryptoException {
+        seal.execute(aad, pt, out);
     }
 
     @Override
-    public ByteBuffer open(ByteBuffer aad, ByteBuffer ct) throws CryptoException {
-        return open.execute(aad, ct);
+    public void open(ByteBuf aad, ByteBuf ct, ByteBuf out) throws CryptoException {
+        open.execute(aad, ct, out);
     }
 }

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleHPKEContext.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleHPKEContext.java
@@ -15,6 +15,7 @@
  */
 package io.netty.incubator.codec.hpke.bouncycastle;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.incubator.codec.hpke.CryptoException;
 import io.netty.incubator.codec.hpke.HPKEContext;
 import org.bouncycastle.crypto.InvalidCipherTextException;
@@ -58,12 +59,12 @@ class BouncyCastleHPKEContext implements HPKEContext {
     }
 
     @Override
-    public ByteBuffer seal(ByteBuffer aad, ByteBuffer pt) throws CryptoException {
-        return seal.execute(aad, pt);
+    public void seal(ByteBuf aad, ByteBuf pt, ByteBuf out) throws CryptoException {
+        seal.execute(aad, pt, out);
     }
 
     @Override
-    public ByteBuffer open(ByteBuffer aad, ByteBuffer ct) throws CryptoException {
-        return open.execute(aad, ct);
+    public void open(ByteBuf aad, ByteBuf ct, ByteBuf out) throws CryptoException {
+        open.execute(aad, ct, out);
     }
 }

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCrypto.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCrypto.java
@@ -16,10 +16,10 @@
 package io.netty.incubator.codec.ohttp;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.incubator.codec.hpke.CryptoException;
 import io.netty.incubator.codec.hpke.CryptoOperations;
 
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -27,34 +27,14 @@ import java.nio.charset.StandardCharsets;
  */
 public abstract class OHttpCrypto {
 
-    private static final byte[] AAD_NONE = new byte[0];
     private static final byte[] AAD_FINAL = "final".getBytes(StandardCharsets.US_ASCII);
 
     // Package-private
     OHttpCrypto() { }
 
-    private static ByteBuffer aad(boolean isFinal) {
+    private static ByteBuf aad(boolean isFinal) {
         // The caller might update the position of the ByteBuffer, so we create a new one each time.
-        return ByteBuffer.wrap(isFinal ? AAD_FINAL : AAD_NONE);
-    }
-
-    /**
-     * Return readable part of the given {@link ByteBuf}.
-     * This method might need to do a copy or not depending on the given {@link ByteBuf}.
-     * <p>
-     * <strong>Important:</strong> The returned {@link ByteBuffer} must be used directly and only in the scope
-     * of the method that is calling it. This is needed as the returned {@link ByteBuffer} is not "stable", which means
-     * it might be changed at any time.
-     *
-     * @param buf       the {@link ByteBuf}
-     * @param length    the length of the readable part.
-     * @return          the {@link ByteBuffer} that contains the readable part.
-     */
-    private static ByteBuffer readableTemporaryBuffer(ByteBuf buf, int length) {
-        if (buf.nioBufferCount() == 1) {
-            return buf.internalNioBuffer(buf.readerIndex(), length);
-        }
-        return buf.nioBuffer(buf.readerIndex(),  length);
+        return isFinal ? Unpooled.wrappedBuffer(AAD_FINAL) : Unpooled.EMPTY_BUFFER;
     }
 
     protected abstract CryptoOperations encryptCrypto();
@@ -67,33 +47,30 @@ public abstract class OHttpCrypto {
      * Encrypt a message of a given length and write the encrypted data to a buffer.
      *
      * @param message           the message
-     * @param messageLength     the length to encrypt
+     * @param messageLength     the length of the message
      * @param isFinal           {@code true} if this is the final message.
      * @param out               {@link ByteBuf} into which the encrypted data is written.
      * @throws CryptoException  thrown when an error happens.
      */
     public final void encrypt(ByteBuf message, int messageLength, boolean isFinal, ByteBuf out) throws CryptoException {
-        final ByteBuffer encrypted = encryptCrypto().seal(
-                aad(isFinal && configuration().useFinalAad()),
-                readableTemporaryBuffer(message, messageLength));
+        encryptCrypto().seal(aad(isFinal && configuration().useFinalAad()),
+                message.slice(message.readerIndex(), messageLength), out);
         message.skipBytes(messageLength);
-        out.writeBytes(encrypted);
     }
 
     /**
      * Decrypt a message of a given length and write the decrypted data to a buffer.
      *
      * @param message           the message
-     * @param messageLength     the length to decrypt
+     * @param messageLength     the length of the message
      * @param isFinal           {@code true} if this is the final message.
      * @param out               {@link ByteBuf} into which the decrypted data is written.
      * @throws CryptoException  thrown when an error happens.
      */
     public final void decrypt(ByteBuf message, int messageLength, boolean isFinal, ByteBuf out) throws CryptoException {
-        final ByteBuffer decrypted = decryptCrypto().open(
+        decryptCrypto().open(
                 aad(isFinal && configuration().useFinalAad()),
-                readableTemporaryBuffer(message, messageLength));
+                message.slice(message.readerIndex(), messageLength), out);
         message.skipBytes(messageLength);
-        out.writeBytes(decrypted);
     }
 }


### PR DESCRIPTION
Motivation:

We should change the API of CryptoOperations to operate on ByteBuf. This will make things more flexible in the future when a native implementation will be provided and also might save some allocations

Modifications:

Change seal / open methods to operate on ByteBuf.

Result:

API cleanup