### PR TITLE
CryptoContext should extend AutoCloseable as depending on the impleme…

### DIFF
--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/CryptoContext.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/CryptoContext.java
@@ -20,7 +20,7 @@ import io.netty.buffer.ByteBuf;
 /**
  * Cryptographic operations to encrypt and decrypt data.
  */
-public interface CryptoContext {
+public interface CryptoContext extends AutoCloseable {
 
     /**
      * Authenticate and encrypt data. The {@link ByteBuf#readerIndex()} will be increased by the amount of
@@ -43,4 +43,11 @@ public interface CryptoContext {
      * @throws      CryptoException in case of an error.
      */
     void open(ByteBuf aad, ByteBuf ct, ByteBuf out) throws CryptoException;
+
+    /**
+     * Closes the {@link CryptoContext} and so release all resources. Calling any method after calling this method
+     * might result in an {@link IllegalStateException}.
+     */
+    @Override
+    void close();
 }

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleAEADCryptoContext.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleAEADCryptoContext.java
@@ -27,6 +27,8 @@ final class BouncyCastleAEADCryptoContext implements AEADContext {
     private final BouncyCastleCryptoOperation open;
     private final BouncyCastleCryptoOperation seal;
 
+    private boolean closed;
+
     BouncyCastleAEADCryptoContext(AEAD aead) {
         this.open = new BouncyCastleCryptoOperation() {
             @Override
@@ -46,11 +48,24 @@ final class BouncyCastleAEADCryptoContext implements AEADContext {
 
     @Override
     public void seal(ByteBuf aad, ByteBuf pt, ByteBuf out) throws CryptoException {
+        checkClosed();
         seal.execute(aad, pt, out);
     }
 
     @Override
     public void open(ByteBuf aad, ByteBuf ct, ByteBuf out) throws CryptoException {
+        checkClosed();
         open.execute(aad, ct, out);
+    }
+
+    private void checkClosed() {
+        if (closed) {
+            throw new IllegalStateException("AEADContext closed");
+        }
+    }
+
+    @Override
+    public void close() {
+        closed = true;
     }
 }

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleHPKEContext.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleHPKEContext.java
@@ -27,6 +27,8 @@ class BouncyCastleHPKEContext implements HPKEContext {
     private final BouncyCastleCryptoOperation seal;
     private final BouncyCastleCryptoOperation open;
 
+    private boolean closed;
+
     BouncyCastleHPKEContext(org.bouncycastle.crypto.hpke.HPKEContext context) {
         this.context = context;
         this.seal = new BouncyCastleCryptoOperation() {
@@ -45,26 +47,42 @@ class BouncyCastleHPKEContext implements HPKEContext {
 
     @Override
     public byte[] export(byte[] exportContext, int length) {
+        checkClosed();
         return context.export(exportContext, length);
     }
 
     @Override
     public byte[] extract(byte[] salt, byte[] ikm) {
+        checkClosed();
         return context.extract(salt, ikm);
     }
 
     @Override
     public byte[] expand(byte[] prk, byte[] info, int length) {
+        checkClosed();
         return context.expand(prk, info, length);
     }
 
     @Override
     public void seal(ByteBuf aad, ByteBuf pt, ByteBuf out) throws CryptoException {
+        checkClosed();
         seal.execute(aad, pt, out);
     }
 
     @Override
     public void open(ByteBuf aad, ByteBuf ct, ByteBuf out) throws CryptoException {
+        checkClosed();
         open.execute(aad, ct, out);
+    }
+
+    private void checkClosed() {
+        if (closed) {
+            throw new IllegalStateException("AEADContext closed");
+        }
+    }
+
+    @Override
+    public void close() {
+        closed = true;
     }
 }

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpClientCodec.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpClientCodec.java
@@ -342,5 +342,10 @@ public final class OHttpClientCodec extends MessageToMessageCodec<HttpObject, Ht
                 throws CryptoException {
             sender.encrypt(chunk, chunkLength, isFinal, out);
         }
+
+        @Override
+        void destroyCrypto() {
+            sender.close();
+        }
     };
 }

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCrypto.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCrypto.java
@@ -25,7 +25,7 @@ import java.nio.charset.StandardCharsets;
 /**
  * Abstract base class for doing OHTTP related crypto operations.
  */
-public abstract class OHttpCrypto {
+public abstract class OHttpCrypto implements AutoCloseable {
 
     private static final byte[] AAD_FINAL = "final".getBytes(StandardCharsets.US_ASCII);
 
@@ -72,5 +72,11 @@ public abstract class OHttpCrypto {
                 aad(isFinal && configuration().useFinalAad()),
                 message.slice(message.readerIndex(), messageLength), out);
         message.skipBytes(messageLength);
+    }
+
+    @Override
+    public void close()  {
+        encryptCrypto().close();
+        decryptCrypto().close();
     }
 }

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpRequestResponseContext.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpRequestResponseContext.java
@@ -153,7 +153,10 @@ abstract class OHttpRequestResponseContext {
             decoder.destroy();
             decoder = null;
         }
+        destroyCrypto();
     }
+
+    abstract void destroyCrypto();
 
     private final class ContentDecoder implements OHttpChunkFramer.Decoder {
 

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
@@ -332,5 +332,10 @@ public class OHttpServerCodec extends MessageToMessageCodec<HttpObject, HttpObje
             sendLastHttpContent = true;
             return receivedLastHttpContent;
         }
+
+        @Override
+        void destroyCrypto() {
+            receiver.close();
+        }
     }
 }


### PR DESCRIPTION
…ntation we might need to release resources

Motivation:

CryptoContext should extend AutoCloseable in prepation for a native implementation. This is needed so we can free up native memory once the context will not be used anymore.

Modifications:

- Let CryptoContext implement AutoCloseable
- Let OHttpCryptoSender and OHttpCryptReceiver implement AutoCloseable
- Adjust tests

Result:

Be able to free up resources once a crypto related context is not used anymore