### PR TITLE
Split crypto related interfaces

### DIFF
--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/CryptoContext.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/CryptoContext.java
@@ -15,34 +15,10 @@
  */
 package io.netty.incubator.codec.hpke;
 
-import io.netty.buffer.ByteBuf;
-
 /**
- * Cryptographic operations to encrypt and decrypt data.
+ * Context for Cryptographic operations.
  */
 public interface CryptoContext extends AutoCloseable {
-
-    /**
-     * Authenticate and encrypt data. The {@link ByteBuf#readerIndex()} will be increased by the amount of
-     * data read and {@link ByteBuf#writerIndex()} by the bytes written.
-     *
-     * @param aad   the AAD buffer
-     * @param pt    the data to encrypt.
-     * @param out   the buffer for writing into
-     * @throws      CryptoException in case of an error.
-     */
-    void seal(ByteBuf aad, ByteBuf pt, ByteBuf out) throws CryptoException;
-
-    /**
-     * Authenticate and decrypt data. The {@link ByteBuf#readerIndex()} will be increased by the amount of
-     * data read and {@link ByteBuf#writerIndex()} by the bytes written.
-     *
-     * @param aad   the AAD buffer
-     * @param ct    the data to decrypt
-     * @param out   the buffer for writing into.
-     * @throws      CryptoException in case of an error.
-     */
-    void open(ByteBuf aad, ByteBuf ct, ByteBuf out) throws CryptoException;
 
     /**
      * Closes the {@link CryptoContext} and so release all resources. Calling any method after calling this method

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/CryptoDecryptContext.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/CryptoDecryptContext.java
@@ -15,10 +15,21 @@
  */
 package io.netty.incubator.codec.hpke;
 
+import io.netty.buffer.ByteBuf;
+
 /**
- * {@link CryptoContext} implementation of
- * <a href="https://datatracker.ietf.org/doc/html/rfc5116">AEAD encryption algorithm [RFC5116]</a>.
+ * {@link CryptoContext} that can be used for decryption.
  */
-public interface AEADContext extends CryptoDecryptContext, CryptoEncryptContext {
-    // TODO: Move some methods in here.
+public interface CryptoDecryptContext extends CryptoContext {
+
+    /**
+     * Authenticate and decrypt data. The {@link ByteBuf#readerIndex()} will be increased by the amount of
+     * data read and {@link ByteBuf#writerIndex()} by the bytes written.
+     *
+     * @param aad   the AAD buffer
+     * @param ct    the data to decrypt
+     * @param out   the buffer for writing into.
+     * @throws      CryptoException in case of an error.
+     */
+    void open(ByteBuf aad, ByteBuf ct, ByteBuf out) throws CryptoException;
 }

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/CryptoEncryptContext.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/CryptoEncryptContext.java
@@ -15,10 +15,21 @@
  */
 package io.netty.incubator.codec.hpke;
 
+import io.netty.buffer.ByteBuf;
+
 /**
- * {@link CryptoContext} implementation of
- * <a href="https://datatracker.ietf.org/doc/html/rfc5116">AEAD encryption algorithm [RFC5116]</a>.
+ * {@link CryptoContext} that can be used for encryption.
  */
-public interface AEADContext extends CryptoDecryptContext, CryptoEncryptContext {
-    // TODO: Move some methods in here.
+public interface CryptoEncryptContext extends CryptoContext {
+
+    /**
+     * Authenticate and encrypt data. The {@link ByteBuf#readerIndex()} will be increased by the amount of
+     * data read and {@link ByteBuf#writerIndex()} by the bytes written.
+     *
+     * @param aad   the AAD buffer
+     * @param pt    the data to encrypt.
+     * @param out   the buffer for writing into
+     * @throws      CryptoException in case of an error.
+     */
+    void seal(ByteBuf aad, ByteBuf pt, ByteBuf out) throws CryptoException;
 }

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/HPKERecipientContext.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/HPKERecipientContext.java
@@ -16,14 +16,7 @@
 package io.netty.incubator.codec.hpke;
 
 /**
- * A {@link HPKEContext} which uses encapsulation.
+ * {@link HPKEContext} that can be used for decryption.
  */
-public interface HPKEContextWithEncapsulation extends HPKEContext {
-
-    /**
-     * Return the bytes that are used for encapsulation.
-     *
-     * @return encapsulation
-     */
-    byte[] encapsulation();
+public interface HPKERecipientContext extends HPKEContext, CryptoDecryptContext {
 }

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/HPKESenderContext.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/HPKESenderContext.java
@@ -15,10 +15,15 @@
  */
 package io.netty.incubator.codec.hpke;
 
+
 /**
- * {@link CryptoContext} implementation of
- * <a href="https://datatracker.ietf.org/doc/html/rfc5116">AEAD encryption algorithm [RFC5116]</a>.
+ * {@link HPKEContext} that can be used for encryption.
  */
-public interface AEADContext extends CryptoDecryptContext, CryptoEncryptContext {
-    // TODO: Move some methods in here.
+public interface HPKESenderContext extends HPKEContext, CryptoEncryptContext {
+    /**
+     * Return the bytes that are used for encapsulation.
+     *
+     * @return encapsulation
+     */
+    byte[] encapsulation();
 }

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/OHttpCryptoProvider.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/OHttpCryptoProvider.java
@@ -32,7 +32,7 @@ public interface OHttpCryptoProvider {
     AEADContext setupAEAD(AEAD aead, byte[] key, byte[] baseNonce);
 
     /**
-     * Establish a {@link HPKEContextWithEncapsulation} that can be used for encryption.
+     * Establish a {@link HPKESenderContext} that can be used for encryption.
      *
      * @param mode  the {@link Mode} to use.
      * @param kem   the {@link KEM} to use.
@@ -43,11 +43,11 @@ public interface OHttpCryptoProvider {
      * @param kpE   the ephemeral keypair or {@code null} if none should be used.
      * @return      the context.
      */
-    HPKEContextWithEncapsulation setupHPKEBaseS(Mode mode, KEM kem, KDF kdf, AEAD aead,
+    HPKESenderContext setupHPKEBaseS(Mode mode, KEM kem, KDF kdf, AEAD aead,
                                                 AsymmetricKeyParameter pkR, byte[] info, AsymmetricCipherKeyPair kpE);
 
     /**
-     * Establish a {@link HPKEContext} that can be used for decryption.
+     * Establish a {@link HPKERecipientContext} that can be used for decryption.
      *
      * @param mode  the {@link Mode} to use.
      * @param kem   the {@link KEM} to use.
@@ -58,7 +58,7 @@ public interface OHttpCryptoProvider {
      * @param info  info parameter.
      * @return      the context.
      */
-    HPKEContext setupHPKEBaseR(Mode mode, KEM kem, KDF kdf, AEAD aead, byte[] enc,
+    HPKERecipientContext setupHPKEBaseR(Mode mode, KEM kem, KDF kdf, AEAD aead, byte[] enc,
                                AsymmetricCipherKeyPair skR, byte[] info);
 
     /**

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleHPKEContext.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleHPKEContext.java
@@ -22,27 +22,12 @@ import org.bouncycastle.crypto.InvalidCipherTextException;
 
 import java.nio.ByteBuffer;
 
-class BouncyCastleHPKEContext implements HPKEContext {
+abstract class BouncyCastleHPKEContext implements HPKEContext {
     protected final org.bouncycastle.crypto.hpke.HPKEContext context;
-    private final BouncyCastleCryptoOperation seal;
-    private final BouncyCastleCryptoOperation open;
-
     private boolean closed;
 
     BouncyCastleHPKEContext(org.bouncycastle.crypto.hpke.HPKEContext context) {
         this.context = context;
-        this.seal = new BouncyCastleCryptoOperation() {
-            @Override
-            protected byte[] execute(byte[] arg1, byte[] arg2, int offset2, int length2) throws InvalidCipherTextException {
-                return context.seal(arg1, arg2, offset2, length2);
-            }
-        };
-        this.open = new BouncyCastleCryptoOperation() {
-            @Override
-            protected byte[] execute(byte[] arg1, byte[] arg2, int offset2, int length2) throws InvalidCipherTextException {
-                return context.open(arg1, arg2, offset2, length2);
-            }
-        };
     }
 
     @Override
@@ -63,19 +48,7 @@ class BouncyCastleHPKEContext implements HPKEContext {
         return context.expand(prk, info, length);
     }
 
-    @Override
-    public void seal(ByteBuf aad, ByteBuf pt, ByteBuf out) throws CryptoException {
-        checkClosed();
-        seal.execute(aad, pt, out);
-    }
-
-    @Override
-    public void open(ByteBuf aad, ByteBuf ct, ByteBuf out) throws CryptoException {
-        checkClosed();
-        open.execute(aad, ct, out);
-    }
-
-    private void checkClosed() {
+    protected void checkClosed() {
         if (closed) {
             throw new IllegalStateException("AEADContext closed");
         }

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleHPKERecipientContext.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleHPKERecipientContext.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.hpke.bouncycastle;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.incubator.codec.hpke.CryptoException;
+import io.netty.incubator.codec.hpke.HPKERecipientContext;
+import org.bouncycastle.crypto.InvalidCipherTextException;
+import org.bouncycastle.crypto.hpke.HPKEContext;
+
+final class BouncyCastleHPKERecipientContext extends BouncyCastleHPKEContext implements HPKERecipientContext {
+    private final BouncyCastleCryptoOperation open;
+
+    BouncyCastleHPKERecipientContext(HPKEContext context) {
+        super(context);
+        open = new BouncyCastleCryptoOperation() {
+            @Override
+            protected byte[] execute(byte[] arg1, byte[] arg2, int offset2, int length2) throws InvalidCipherTextException {
+                return context.open(arg1, arg2, offset2, length2);
+            }
+        };
+    }
+
+    @Override
+    public void open(ByteBuf aad, ByteBuf ct, ByteBuf out) throws CryptoException {
+        checkClosed();
+        open.execute(aad, ct, out);
+    }
+}

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleOHttpCryptoProvider.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleOHttpCryptoProvider.java
@@ -18,8 +18,8 @@ package io.netty.incubator.codec.hpke.bouncycastle;
 import io.netty.incubator.codec.hpke.AEADContext;
 import io.netty.incubator.codec.hpke.AsymmetricCipherKeyPair;
 import io.netty.incubator.codec.hpke.AsymmetricKeyParameter;
-import io.netty.incubator.codec.hpke.HPKEContext;
-import io.netty.incubator.codec.hpke.HPKEContextWithEncapsulation;
+import io.netty.incubator.codec.hpke.HPKERecipientContext;
+import io.netty.incubator.codec.hpke.HPKESenderContext;
 import io.netty.incubator.codec.hpke.OHttpCryptoProvider;
 import org.bouncycastle.crypto.params.ECDomainParameters;
 import org.bouncycastle.crypto.params.ECPrivateKeyParameters;
@@ -62,7 +62,7 @@ public final class BouncyCastleOHttpCryptoProvider implements OHttpCryptoProvide
     }
 
     @Override
-    public HPKEContextWithEncapsulation setupHPKEBaseS(Mode mode, KEM kem, KDF kdf, AEAD aead,
+    public HPKESenderContext setupHPKEBaseS(Mode mode, KEM kem, KDF kdf, AEAD aead,
                                                        AsymmetricKeyParameter pkR, byte[] info,
                                                        AsymmetricCipherKeyPair kpE) {
         org.bouncycastle.crypto.hpke.HPKE hpke =
@@ -73,15 +73,15 @@ public final class BouncyCastleOHttpCryptoProvider implements OHttpCryptoProvide
         } else {
             ctx = hpke.setupBaseS(castOrThrow(pkR).param, info, castOrThrow(kpE).pair);
         }
-        return new BouncyCastleHPKEContextWithEncapsulation(ctx);
+        return new BouncyCastleHPKESenderContext(ctx);
     }
 
     @Override
-    public HPKEContext setupHPKEBaseR(Mode mode, KEM kem, KDF kdf, AEAD aead, byte[] enc,
-                                      AsymmetricCipherKeyPair skR, byte[] info) {
+    public HPKERecipientContext setupHPKEBaseR(Mode mode, KEM kem, KDF kdf, AEAD aead, byte[] enc,
+                                               AsymmetricCipherKeyPair skR, byte[] info) {
         org.bouncycastle.crypto.hpke.HPKE hpke =
                 new org.bouncycastle.crypto.hpke.HPKE(mode.value(), kem.id(), kdf.id(), aead.id());
-        return new BouncyCastleHPKEContext(hpke.setupBaseR(enc, castOrThrow(skR).pair, info));
+        return new BouncyCastleHPKERecipientContext(hpke.setupBaseR(enc, castOrThrow(skR).pair, info));
     }
 
     @Override

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCiphersuite.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCiphersuite.java
@@ -15,6 +15,7 @@
  */
 package io.netty.incubator.codec.ohttp;
 
+import io.netty.incubator.codec.hpke.AEADContext;
 import io.netty.incubator.codec.hpke.CryptoContext;
 import io.netty.incubator.codec.hpke.HPKEContext;
 import io.netty.incubator.codec.hpke.OHttpCryptoProvider;
@@ -125,8 +126,8 @@ public final class OHttpCiphersuite {
     /*
      * See https://ietf-wg-ohai.github.io/oblivious-http/draft-ietf-ohai-ohttp.html#name-encapsulation-of-responses
      */
-    CryptoContext createResponseAead(OHttpCryptoProvider provider, HPKEContext context, byte[] enc,
-                                     byte[] responseNonce, OHttpCryptoConfiguration configuration) {
+    AEADContext createResponseAead(OHttpCryptoProvider provider, HPKEContext context, byte[] enc,
+                                                 byte[] responseNonce, OHttpCryptoConfiguration configuration) {
         int secretLength = Math.max(aead.nk(), aead.nn());
         byte[] secret = context.export(configuration.responseExportContext(), secretLength);
         byte[] salt = Arrays.concatenate(enc, responseNonce);

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCrypto.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCrypto.java
@@ -17,6 +17,8 @@ package io.netty.incubator.codec.ohttp;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.incubator.codec.hpke.CryptoDecryptContext;
+import io.netty.incubator.codec.hpke.CryptoEncryptContext;
 import io.netty.incubator.codec.hpke.CryptoException;
 import io.netty.incubator.codec.hpke.CryptoContext;
 
@@ -37,9 +39,9 @@ public abstract class OHttpCrypto implements AutoCloseable {
         return isFinal ? Unpooled.wrappedBuffer(AAD_FINAL) : Unpooled.EMPTY_BUFFER;
     }
 
-    protected abstract CryptoContext encryptCrypto();
+    protected abstract CryptoEncryptContext encryptCrypto();
 
-    protected abstract CryptoContext decryptCrypto();
+    protected abstract CryptoDecryptContext decryptCrypto();
 
     protected abstract OHttpCryptoConfiguration configuration();
 

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCryptoReceiver.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCryptoReceiver.java
@@ -17,9 +17,12 @@ package io.netty.incubator.codec.ohttp;
 
 import io.netty.incubator.codec.hpke.AsymmetricCipherKeyPair;
 import io.netty.incubator.codec.hpke.CryptoContext;
+import io.netty.incubator.codec.hpke.CryptoDecryptContext;
+import io.netty.incubator.codec.hpke.CryptoEncryptContext;
 import io.netty.incubator.codec.hpke.HPKEContext;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.DecoderException;
+import io.netty.incubator.codec.hpke.HPKERecipientContext;
 import io.netty.incubator.codec.hpke.OHttpCryptoProvider;
 
 import static java.util.Objects.requireNonNull;
@@ -29,9 +32,9 @@ import static java.util.Objects.requireNonNull;
  */
 public final class OHttpCryptoReceiver extends OHttpCrypto {
     private final OHttpCryptoConfiguration configuration;
-    private final HPKEContext context;
+    private final HPKERecipientContext context;
     private final byte[] responseNonce;
-    private final CryptoContext aead;
+    private final CryptoEncryptContext aead;
 
     public final static class Builder {
         private OHttpCryptoProvider provider;
@@ -120,12 +123,12 @@ public final class OHttpCryptoReceiver extends OHttpCrypto {
     }
 
     @Override
-    protected CryptoContext encryptCrypto() {
+    protected CryptoEncryptContext encryptCrypto() {
         return this.aead;
     }
 
     @Override
-    protected CryptoContext decryptCrypto() {
+    protected CryptoDecryptContext decryptCrypto() {
         return this.context;
     }
 

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCryptoSender.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCryptoSender.java
@@ -17,9 +17,10 @@ package io.netty.incubator.codec.ohttp;
 
 import io.netty.incubator.codec.hpke.AsymmetricCipherKeyPair;
 import io.netty.incubator.codec.hpke.AsymmetricKeyParameter;
-import io.netty.incubator.codec.hpke.CryptoContext;
-import io.netty.incubator.codec.hpke.HPKEContextWithEncapsulation;
+import io.netty.incubator.codec.hpke.CryptoDecryptContext;
+import io.netty.incubator.codec.hpke.CryptoEncryptContext;
 import io.netty.buffer.ByteBuf;
+import io.netty.incubator.codec.hpke.HPKESenderContext;
 import io.netty.incubator.codec.hpke.OHttpCryptoProvider;
 
 import static java.util.Objects.requireNonNull;
@@ -32,8 +33,8 @@ public final class OHttpCryptoSender extends OHttpCrypto {
     private final OHttpCryptoConfiguration configuration;
     private final OHttpCiphersuite ciphersuite;
     private final OHttpCryptoProvider provider;
-    private final HPKEContextWithEncapsulation context;
-    private CryptoContext aead;
+    private final HPKESenderContext context;
+    private CryptoDecryptContext aead;
 
     public static final class Builder {
         private OHttpCryptoProvider provider;
@@ -134,12 +135,12 @@ public final class OHttpCryptoSender extends OHttpCrypto {
     }
 
     @Override
-    protected CryptoContext encryptCrypto() {
+    protected CryptoEncryptContext encryptCrypto() {
         return context;
     }
 
     @Override
-    protected CryptoContext decryptCrypto() {
+    protected CryptoDecryptContext decryptCrypto() {
         return aead;
     }
 


### PR DESCRIPTION
Motivation:

When setup the HPKE context you either set it up for encryption or decryption. We should change our interfaces to reflect this and so guard the user from miss-usage.

Modifications:

Introduce sub-types to support either encryption or decryption

Result:

Guard users from incorrect setup and usage of context