### PR TITLE
Add BoringSSL based native HPKE implementation

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -29,28 +29,58 @@ env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
 
 jobs:
-  build:
+  build-linux-x86_64:
     runs-on: ubuntu-latest
+    name: linux-x86_64
     steps:
       - uses: actions/checkout@v4
 
-      # Cache .m2/repository
+      # Caching of maven dependencies
       - uses: actions/cache@v3
         continue-on-error: true
         with:
           path: ~/.m2/repository
-          key: build-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
+          key: build-linux-x86_64-maven-cache-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            build-cache-m2-repository-
+            build-linux-x86_64-maven-cache-
 
       - name: Build docker image
         run: docker-compose -f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml build
 
-      - name: Execute project build without leak detection
-        run: docker-compose -f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml run build | tee build-leak.output
+      - name: Build project without leak detection
+        run: docker-compose -f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml run build | tee build.output
 
       - name: Checking for test failures
-        run: ./.github/scripts/check_build_result.sh build-leak.output
+        run: ./.github/scripts/check_build_result.sh build.output
+
+      - uses: actions/upload-artifact@v3
+        if: ${{ failure() }}
+        with:
+          name: target
+          path: |
+            **/target/surefire-reports/
+            **/hs_err*.log
+
+  build-linux-aarch64:
+    runs-on: ubuntu-latest
+    name: linux-aarch64
+    steps:
+      - uses: actions/checkout@v4
+
+      # Caching of maven dependencies
+      - uses: actions/cache@v3
+        continue-on-error: true
+        with:
+          path: ~/.m2/repository
+          key: build-linux-aarch64-maven-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            build-linux-aarch64-maven-cache-
+
+      - name: Build docker image
+        run: docker-compose -f docker/docker-compose.centos-7-cross.yaml build
+
+      - name: Build project without leak detection
+        run: docker-compose -f docker/docker-compose.centos-7-cross.yaml run cross-compile-aarch64-build
 
       - uses: actions/upload-artifact@v3
         if: ${{ failure() }}

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -20,7 +20,7 @@ on:
     branches: [ main ]
 
   schedule:
-    - cron: '30 8 * * 1'  # At 08:30 on Monday, every Monday.
+    - cron: '30 7 * * 1'  # At 07:30 on Monday, every Monday.
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -29,31 +29,108 @@ env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
 
 jobs:
-  deploy:
+  stage-snapshot-linux:
     runs-on: ubuntu-latest
-    steps:
-      - uses: s4u/maven-settings-action@v2.8.0
-        with:
-          servers: |
-            [{
-                "id": "sonatype-nexus-snapshots",
-                "username": "${{ secrets.SONATYPE_USERNAME }}",
-                "password": "${{ secrets.SONATYPE_PASSWORD }}"
-            }]
+    strategy:
+      matrix:
+        include:
+          - setup: linux-x86_64
+            docker-compose-build: "-f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml build"
+            docker-compose-run: "-f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml run stage-snapshot"
+          - setup: linux-aarch64
+            docker-compose-build: "-f docker/docker-compose.centos-7-cross.yaml build"
+            docker-compose-run: "-f docker/docker-compose.centos-7-cross.yaml run cross-compile-aarch64-stage-snapshot"
 
+    name: stage-snapshot-${{ matrix.setup }}
+    steps:
       - uses: actions/checkout@v4
 
-      # Cache .m2/repository
+      # Caching of maven dependencies
       - uses: actions/cache@v3
         continue-on-error: true
         with:
           path: ~/.m2/repository
-          key: deploy-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
+          key: stage-snapshot-${{ matrix.setup }}-maven-cache-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            deploy-cache-m2-repository-
+            stage-snapshot-${{ matrix.setup }}-maven-cache-
+
+      - uses: s4u/maven-settings-action@v2.8.0
+        with:
+          servers: |
+            [{
+              "id": "sonatype-nexus-staging",
+              "username": "${{ secrets.SONATYPE_USERNAME }}",
+              "password": "${{ secrets.SONATYPE_PASSWORD }}"
+            }]
+
+      - name: Create local staging directory
+        run: mkdir -p ~/local-staging
 
       - name: Build docker image
-        run: docker-compose -f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml build
+        run: docker-compose ${{ matrix.docker-compose-build }}
 
-      - name: Deploy project snapshot to sonatype
-        run: docker-compose -f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml run deploy
+      - name: Stage snapshots to local staging directory
+        run: docker-compose ${{ matrix.docker-compose-run }}
+
+      - name: Upload local staging directory
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.setup }}-local-staging
+          path: ~/local-staging
+          if-no-files-found: error
+
+  deploy-staged-snapshots:
+    runs-on: ubuntu-latest
+    # Wait until we have staged everything
+    needs: [stage-snapshot-linux]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: 8
+
+      # Caching of maven dependencies
+      - uses: actions/cache@v3
+        continue-on-error: true
+        with:
+          path: ~/.m2/repository
+          key: deploy-staged-snapshots-maven-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            deploy-staged-snapshots-maven-cache-
+
+      # Setup some env to re-use later.
+      - name: Prepare enviroment variables
+        run: |
+          echo "LOCAL_STAGING_DIR=$HOME/local-staging" >> $GITHUB_ENV
+
+      # Hardcode the staging artifacts that need to be downloaded.
+      # These must match the matrix setups and windows build. There is currently no way to pull this out of the config.
+      - name: Download linux-aarch64 staging directory
+        uses: actions/download-artifact@v3
+        with:
+          name: linux-aarch64-local-staging
+          path: ~/linux-aarch64-local-staging
+
+      - name: Download linux-x86_64 staging directory
+        uses: actions/download-artifact@v3
+        with:
+          name: linux-x86_64-local-staging
+          path: ~/linux-x86_64-local-staging
+
+      - name: Merge staging repositories
+        run: bash ./.github/scripts/merge_local_staging.sh ~/local-staging ~/linux-aarch64-local-staging ~/linux-x86_64-local-staging
+
+      - uses: s4u/maven-settings-action@v2.8.0
+        with:
+          servers: |
+            [{
+              "id": "sonatype-nexus-snapshots",
+              "username": "${{ secrets.SONATYPE_USERNAME }}",
+              "password": "${{ secrets.SONATYPE_PASSWORD }}"
+            }]
+
+      - name: Deploy local staged artifacts
+        run: ./mvnw -B -ntp --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DaltStagingDirectory=$LOCAL_STAGING_DIR

--- a/.github/workflows/ci-pr-reports.yml
+++ b/.github/workflows/ci-pr-reports.yml
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright 2023 The Netty Project
+# Copyright 2021 The Netty Project
 #
 # The Netty Project licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance
@@ -23,9 +23,24 @@ on:
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
 
+permissions:
+  contents: read
+
 jobs:
   tests:
+    permissions:
+      actions: read  # for dawidd6/action-download-artifact to query and download artifacts
+      checks: write  # for scacap/action-surefire-report to publish result as PR check
+      pull-requests: read  # for dawidd6/action-download-artifact to query commit hash
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ignore-if-missing: [false]
+        include:
+          - setup: linux-x86_64-java8
+          - setup: linux-x86_64-java17
+    continue-on-error: ${{ matrix.ignore-if-missing }}
     steps:
       - name: Download Artifacts
         uses: dawidd6/action-download-artifact@v2.28.0
@@ -35,11 +50,11 @@ jobs:
           workflow_conclusion: completed
           commit: ${{ github.event.workflow_run.head_commit.id }}
           # File location set in ci-pr.yml and must be coordinated.
-          name: test-results-build
+          name: test-results-${{ matrix.setup }}
       - name: Publish Test Report
         uses: scacap/action-surefire-report@v1.7.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/target/surefire-reports/TEST-*.xml'
           commit: ${{ github.event.workflow_run.head_commit.id }}
-          check_name: test reports
+          check_name: ${{ matrix.setup }} test reports

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -26,50 +26,47 @@ env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
 
 jobs:
-  verify:
+  build-pr:
+    strategy:
+      matrix:
+        include:
+          - setup: linux-x86_64-java8
+            docker-compose-build: "-f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml build"
+            docker-compose-run: "-f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml run build-leak"
+          - setup: linux-x86_64-java8-no-unsafe
+            docker-compose-build: "-f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml build"
+            docker-compose-run: "-f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml run build-no-unsafe"
+          - setup: linux-x86_64-java17
+            docker-compose-build: "-f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.117.yaml build"
+            docker-compose-run: "-f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.117.yaml run build-leak"
+          - setup: linux-x86_64-java21
+            docker-compose-build: "-f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.21.yaml build"
+            docker-compose-run: "-f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.21.yaml run build-leak"
+          - setup: linux-aarch64-java8
+            docker-compose-build: "-f docker/docker-compose.centos-7-cross.yaml build"
+            docker-compose-run: "-f docker/docker-compose.centos-7-cross.yaml run cross-compile-aarch64-build"
+
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK 8
-        uses: actions/setup-java@v3
-        with:
-          java-version: 8
-          distribution: 'zulu'
-      # Cache .m2/repository
-      - uses: actions/cache@v3
-        continue-on-error: true
-        with:
-          path: ~/.m2/repository
-          key: verify-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            verify-cache-m2-repository-
-
-      - name: Install tools / libraries
-        run: sudo apt-get update && sudo apt-get -y install autoconf automake libtool make tar cmake perl ninja-build git
-
-      - name: Verify with Maven
-        run: ./mvnw -B --file pom.xml verify -DskipTests=true
-
-  build:
-    runs-on: ubuntu-latest
-    needs: verify
+    name: ${{ matrix.setup }} build
     steps:
       - uses: actions/checkout@v4
 
       # Cache .m2/repository
-      - uses: actions/cache@v3
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
         continue-on-error: true
         with:
           path: ~/.m2/repository
-          key: pr-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-${{ matrix.setup }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            pr-cache-m2-repository-
+            ${{ runner.os }}-maven-${{ matrix.setup }}-
+            ${{ runner.os }}-maven-
 
       - name: Build docker image
-        run: docker-compose -f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml build
+        run: docker-compose ${{ matrix.docker-compose-build }}
 
-      - name: Execute project build with leak detection
-        run: docker-compose -f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml run build-leak | tee build-leak.output
+      - name: Build project with leak detection
+        run: docker-compose ${{ matrix.docker-compose-run }} | tee build-leak.output
 
       - name: Checking for test failures
         run: ./.github/scripts/check_build_result.sh build-leak.output
@@ -81,13 +78,14 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: test-results-build
+          name: test-results-${{ matrix.setup }}
           path: '**/target/surefire-reports/TEST-*.xml'
 
       - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
-          name: target
+          name: build-${{ matrix.setup }}-target
           path: |
             **/target/surefire-reports/
             **/hs_err*.log
+            **/core.*

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -43,8 +43,12 @@ jobs:
           key: verify-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             verify-cache-m2-repository-
+
+      - name: Install tools / libraries
+        run: sudo apt-get update && sudo apt-get -y install autoconf automake libtool make tar cmake perl ninja-build git
+
       - name: Verify with Maven
-        run: ./mvnw -B --file pom.xml verify -DskipTests=true -DskipH3Spec=true
+        run: ./mvnw -B --file pom.xml verify -DskipTests=true
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -13,17 +13,17 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 # ----------------------------------------------------------------------------
-name: Release project
+name: Release
 
 on:
-  # Allows you to run this workflow manually from the Actions tab
+  # Releases can only be triggered via the action tab
   workflow_dispatch:
 
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
 
 jobs:
-  release:
+  prepare-release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,15 +33,8 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
+          distribution: zulu
           java-version: 8
-          distribution: 'zulu'
-
-      - name: Import GPG key
-        id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v6
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Setup git configuration
         run: |
@@ -54,31 +47,194 @@ jobs:
           key: ${{ secrets.SSH_PRIVATE_KEY_PEM }}
           known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
 
-      - uses: s4u/maven-settings-action@v2.8.0
-        with:
-          servers: |
-            [{
-                "id": "sonatype-nexus",
-                "username": "${{ secrets.SONATYPE_USERNAME }}",
-                "password": "${{ secrets.SONATYPE_PASSWORD }}"
-            }]
-
-      # Cache .m2/repository
+      # Caching of maven dependencies
       - uses: actions/cache@v3
         continue-on-error: true
         with:
           path: ~/.m2/repository
-          key: release-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
+          key: prepare-release-maven-cache-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            release-cache-m2-repository-
+            prepare-release-maven-cache-
 
       - name: Prepare release with Maven
-        run: ./mvnw -B --file pom.xml release:prepare -DpreparationGoals=clean -DskipTests=true -DskipH3Spec=true
+        run: |
+          ./mvnw -B -ntp --file pom.xml -DskipTests=true -DpreparationGoals=clean release:prepare
+          ./mvnw -B -ntp clean
 
-      - name: Perform release with Maven
-        run: ./mvnw -B --file pom.xml release:perform -Drelease.gpg.keyname=${{ secrets.GPG_KEYNAME }} -Drelease.gpg.passphrase=${{ secrets.GPG_PASSPHRASE }} -DstagingProgressTimeoutMinutes=10
+      - name: Checkout tag
+        run: ./.github/scripts/release_checkout_tag.sh release.properties
+
+      - name: Upload workspace
+        uses: actions/upload-artifact@v3
+        with:
+          name: prepare-release-workspace
+          path: ${{ github.workspace }}/**
+
+  stage-release-linux:
+    runs-on: ubuntu-latest
+    needs: prepare-release
+    strategy:
+      matrix:
+        include:
+          - setup: linux-x86_64
+            docker-compose-build: "-f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml build"
+            docker-compose-run: "-f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml run stage-release"
+          - setup: linux-aarch64
+            docker-compose-build: "-f docker/docker-compose.centos-7-cross.yaml build"
+            docker-compose-run: "-f docker/docker-compose.centos-7-cross.yaml run cross-compile-aarch64-stage-release"
+
+    name: stage-release-${{ matrix.setup }}
+
+    steps:
+      - name: Download release-workspace
+        uses: actions/download-artifact@v3
+        with:
+          name: prepare-release-workspace
+          path: ./prepare-release-workspace/
+
+      - name: Adjust mvnw permissions
+        run: chmod 755 ./prepare-release-workspace/mvnw
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: 8
+
+      - name: Setup git configuration
+        run: |
+          git config --global user.email "netty-project-bot@users.noreply.github.com"
+          git config --global user.name "Netty Project Bot"
+
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_PRIVATE_KEY_PEM }}
+          known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
+
+      # Caching of maven dependencies
+      - uses: actions/cache@v3
+        continue-on-error: true
+        with:
+          path: ~/.m2/repository
+          key: staging-${{ matrix.setup }}-maven-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            staging-${{ matrix.setup }}-maven-cache-
+
+      - uses: s4u/maven-settings-action@v2.8.0
+        with:
+          servers: |
+            [{
+              "id": "sonatype-nexus-staging",
+              "username": "${{ secrets.SONATYPE_USERNAME }}",
+              "password": "${{ secrets.SONATYPE_PASSWORD }}"
+            }]
+
+      - name: Create local staging directory
+        run: mkdir -p ~/local-staging
+
+      - name: Build docker image
+        working-directory: ./prepare-release-workspace/
+        run: docker-compose ${{ matrix.docker-compose-build }}
+
+      - name: Stage release to local staging directory
+        working-directory: ./prepare-release-workspace/
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_KEYNAME: ${{ secrets.GPG_KEYNAME }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: docker-compose ${{ matrix.docker-compose-run }}
+
+      - name: Upload local staging directory
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.setup }}-local-staging
+          path: ~/local-staging
+          if-no-files-found: error
 
       - name: Rollback release on failure
+        working-directory: ./prepare-release-workspace/
         if: ${{ failure() }}
         # Rollback the release in case of an failure
-        run: bash ./.github/scripts/release_rollback.sh release.properties
+        run: bash ./.github/scripts/release_rollback.sh release.properties netty/netty-incubator-codec-ohttp main
+
+  deploy-staged-release:
+    runs-on: ubuntu-latest
+    # Wait until we have staged everything
+    needs: [stage-release-linux]
+    steps:
+      - name: Download release-workspace
+        uses: actions/download-artifact@v3
+        with:
+          name: prepare-release-workspace
+          path: ./prepare-release-workspace/
+
+      - name: Adjust mvnw permissions
+        run: chmod 755 ./prepare-release-workspace/mvnw
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: 8
+
+      - name: Setup git configuration
+        run: |
+          git config --global user.email "netty-project-bot@users.noreply.github.com"
+          git config --global user.name "Netty Project Bot"
+
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_PRIVATE_KEY_PEM }}
+          known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
+
+      # Hardcode the staging artifacts that need to be downloaded.
+      # These must match the matrix setups. There is currently no way to pull this out of the config.
+      - name: Download linux-aarch64 staging directory
+        uses: actions/download-artifact@v3
+        with:
+          name: linux-aarch64-local-staging
+          path: ~/linux-aarch64-local-staging
+
+      - name: Download linux-x86_64 staging directory
+        uses: actions/download-artifact@v3
+        with:
+          name: linux-x86_64-local-staging
+          path: ~/linux-x86_64-local-staging
+
+      # This step takes care of merging all the previous staged repositories in a way that will allow us to deploy
+      # all together with one maven command.
+      - name: Merge staging repositories
+        working-directory: ./prepare-release-workspace/
+        run: bash ./.github/scripts/merge_local_staging.sh /home/runner/local-staging/staging ~/linux-aarch64-local-staging/staging ~/linux-x86_64-local-staging/staging
+
+      # Caching of maven dependencies
+      - uses: actions/cache@v3
+        continue-on-error: true
+        with:
+          path: ~/.m2/repository
+          key: deploy-staged-release-maven-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            deploy-staged-release-maven-cache-
+
+      - uses: s4u/maven-settings-action@v2.8.0
+        with:
+          servers: |
+            [{
+              "id": "sonatype-nexus-staging",
+              "username": "${{ secrets.SONATYPE_USERNAME }}",
+              "password": "${{ secrets.SONATYPE_PASSWORD }}"
+            }]
+
+      - name: Deploy local staged artifacts
+        working-directory: ./prepare-release-workspace/
+        # If we don't want to close the repository we can add -DskipStagingRepositoryClose=true
+        run: ./mvnw -B -ntp --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/home/runner/local-staging -DskipStagingRepositoryClose=true
+
+      - name: Rollback release on failure
+        working-directory: ./prepare-release-workspace/
+        if: ${{ failure() }}
+        # Rollback the release in case of an failure
+        run: bash ./.github/scripts/release_rollback.sh release.properties netty/netty-incubator-codec-ohttp main
+

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'java' ]
+        language: [ 'cpp', 'java' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more...
         # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
@@ -63,8 +63,11 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
+    - name: Install tools / libraries
+      run: sudo apt-get update && sudo apt-get -y install autoconf automake libtool make tar cmake perl ninja-build git
+
     - name: Build project
-      run: ./mvnw clean package -DskipTests=true -DskipH3Spec=true
+      run: ./mvnw clean package -DskipTests=true
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleAEADCryptoContext.java
+++ b/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleAEADCryptoContext.java
@@ -18,7 +18,6 @@ package io.netty.incubator.codec.hpke.bouncycastle;
 import io.netty.buffer.ByteBuf;
 import io.netty.incubator.codec.hpke.AEADContext;
 import io.netty.incubator.codec.hpke.CryptoException;
-import io.netty.incubator.codec.hpke.CryptoContext;
 import org.bouncycastle.crypto.InvalidCipherTextException;
 import org.bouncycastle.crypto.hpke.AEAD;
 
@@ -26,7 +25,6 @@ final class BouncyCastleAEADCryptoContext implements AEADContext {
 
     private final BouncyCastleCryptoOperation open;
     private final BouncyCastleCryptoOperation seal;
-
     private boolean closed;
 
     BouncyCastleAEADCryptoContext(AEAD aead) {

--- a/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleHPKEContext.java
+++ b/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleHPKEContext.java
@@ -15,12 +15,7 @@
  */
 package io.netty.incubator.codec.hpke.bouncycastle;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.incubator.codec.hpke.CryptoException;
 import io.netty.incubator.codec.hpke.HPKEContext;
-import org.bouncycastle.crypto.InvalidCipherTextException;
-
-import java.nio.ByteBuffer;
 
 abstract class BouncyCastleHPKEContext implements HPKEContext {
     protected final org.bouncycastle.crypto.hpke.HPKEContext context;

--- a/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleOHttpCryptoProvider.java
+++ b/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleOHttpCryptoProvider.java
@@ -35,8 +35,16 @@ import org.bouncycastle.math.ec.custom.sec.SecP521R1Curve;
 import org.bouncycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 public final class BouncyCastleOHttpCryptoProvider implements OHttpCryptoProvider {
+
+    private static final List<AEAD> SUPPORTED_AEAD_LIST = Collections.unmodifiableList(Arrays.asList(AEAD.values()));
+    private static final List<Mode> SUPPORTED_MODE_LIST = Collections.unmodifiableList(Arrays.asList(Mode.values()));
+    private static final List<KEM> SUPPORTED_KEM_LIST = Collections.unmodifiableList(Arrays.asList(KEM.values()));
+    private static final List<KDF> SUPPORTED_KDF_LIST = Collections.unmodifiableList(Arrays.asList(KDF.values()));
 
     public static final BouncyCastleOHttpCryptoProvider INSTANCE = new BouncyCastleOHttpCryptoProvider();
 
@@ -179,5 +187,25 @@ public final class BouncyCastleOHttpCryptoProvider implements OHttpCryptoProvide
             default:
                 throw new IllegalArgumentException("invalid kem: " + kem);
         }
+    }
+
+    @Override
+    public List<AEAD> supportedAEAD() {
+        return SUPPORTED_AEAD_LIST;
+    }
+
+    @Override
+    public List<KEM> supportedKEM() {
+        return SUPPORTED_KEM_LIST;
+    }
+
+    @Override
+    public List<KDF> supportedKDF() {
+        return SUPPORTED_KDF_LIST;
+    }
+
+    @Override
+    public List<Mode> supportedMode() {
+        return SUPPORTED_MODE_LIST;
     }
 }

--- a/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleOHttpCryptoProvider.java
+++ b/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleOHttpCryptoProvider.java
@@ -57,14 +57,14 @@ public final class BouncyCastleOHttpCryptoProvider implements OHttpCryptoProvide
 
     private static BouncyCastleAsymmetricKeyParameter castOrThrow(AsymmetricKeyParameter param) {
         if (!(param instanceof BouncyCastleAsymmetricKeyParameter)) {
-            throw new IllegalArgumentException("param must be of type " + BouncyCastleAsymmetricKeyParameter.class);
+            throw new IllegalArgumentException("param must be of type " + BouncyCastleAsymmetricKeyParameter.class + ": " + param);
         }
         return (BouncyCastleAsymmetricKeyParameter) param;
     }
 
     private static BouncyCastleAsymmetricCipherKeyPair castOrThrow(AsymmetricCipherKeyPair pair) {
         if (!(pair instanceof BouncyCastleAsymmetricCipherKeyPair)) {
-            throw new IllegalArgumentException("pair must be of type " + BouncyCastleAsymmetricCipherKeyPair.class);
+            throw new IllegalArgumentException("pair must be of type " + BouncyCastleAsymmetricCipherKeyPair.class + ": " + pair);
         }
         return (BouncyCastleAsymmetricCipherKeyPair) pair;
     }

--- a/codec-ohttp-hpke-classes-boringssl/pom.xml
+++ b/codec-ohttp-hpke-classes-boringssl/pom.xml
@@ -24,7 +24,7 @@
         <version>0.0.3.Final-SNAPSHOT</version>
     </parent>
 
-    <artifactId>netty-incubator-ohttp-hpke-classes-boringssl</artifactId>
+    <artifactId>netty-incubator-codec-ohttp-hpke-classes-boringssl</artifactId>
     <version>0.0.3.Final-SNAPSHOT</version>
     <name>Netty/Incubator/Codec/OHTTP/HPKE/Classes/BoringSSL</name>
 

--- a/codec-ohttp-hpke-classes-boringssl/pom.xml
+++ b/codec-ohttp-hpke-classes-boringssl/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2023 The Netty Project
+  ~
+  ~ The Netty Project licenses this file to you under the Apache License,
+  ~ version 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at:
+  ~
+  ~   https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.netty.incubator</groupId>
+        <artifactId>netty-incubator-codec-parent-ohttp</artifactId>
+        <version>0.0.3.Final-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>netty-incubator-ohttp-hpke-classes-boringssl</artifactId>
+    <version>0.0.3.Final-SNAPSHOT</version>
+    <name>Netty/Incubator/Codec/OHTTP/HPKE/Classes/BoringSSL</name>
+
+    <packaging>jar</packaging>
+
+    <properties>
+        <javaModuleName>io.netty.incubator.codec.hpke.classes.boringssl</javaModuleName>
+    </properties>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                </manifest>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
+                                </manifestEntries>
+                                <index>true</index>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty.incubator</groupId>
+            <artifactId>netty-incubator-codec-ohttp-hpke</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSL.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSL.java
@@ -75,8 +75,8 @@ final class BoringSSL {
             BoringSSLNativeStaticallyReferencedJniMethods.EVP_AEAD_DEFAULT_TAG_LENGTH();
 
     static native long EVP_HPKE_CTX_new();
-    static native long EVP_HPKE_CTX_cleanup(long ctx);
-    static native long EVP_HPKE_CTX_free(long ctx);
+    static native void EVP_HPKE_CTX_cleanup(long ctx);
+    static native void EVP_HPKE_CTX_free(long ctx);
 
     // TODO: Do we also need the auth methods ?
     static native byte[] EVP_HPKE_CTX_setup_sender(
@@ -110,7 +110,6 @@ final class BoringSSL {
     static native int EVP_AEAD_key_length(long aead);
     static native int EVP_AEAD_nonce_length(long aead);
     static native int EVP_AEAD_max_overhead(long aead);
-    static native int EVP_AEAD_max_tag_len(long aead);
 
     static native long EVP_AEAD_CTX_new(long aead, byte[] key, int tag_len);
     static native void EVP_AEAD_CTX_cleanup(long ctx);

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSL.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSL.java
@@ -74,6 +74,13 @@ final class BoringSSL {
     static final int EVP_AEAD_DEFAULT_TAG_LENGTH =
             BoringSSLNativeStaticallyReferencedJniMethods.EVP_AEAD_DEFAULT_TAG_LENGTH();
 
+    static final long EVP_aead_aes_128_gcm =
+            BoringSSLNativeStaticallyReferencedJniMethods.EVP_aead_aes_128_gcm();
+    static final long EVP_aead_aes_256_gcm =
+            BoringSSLNativeStaticallyReferencedJniMethods.EVP_aead_aes_256_gcm();
+    static final long EVP_aead_chacha20_poly1305 =
+            BoringSSLNativeStaticallyReferencedJniMethods.EVP_aead_chacha20_poly1305();
+
     static native long EVP_HPKE_CTX_new();
     static native void EVP_HPKE_CTX_cleanup(long ctx);
     static native void EVP_HPKE_CTX_free(long ctx);

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSL.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSL.java
@@ -90,8 +90,10 @@ final class BoringSSL {
             long ctx, long out, int max_out_len, long in, int in_len, long ad, int ad_len);
     static native int EVP_HPKE_CTX_seal(
             long ctx, long out, int max_out_len, long in, int in_len, long ad, int ad_len);
-    static native int EVP_HPKE_CTX_export(
-            long ctx, long out, int secret_len, long context, int context_len);
+    static native byte[] EVP_HPKE_CTX_export(
+            long ctx, int secret_len, byte[] context);
+
+    static native long EVP_HPKE_CTX_kdf(long ctx);
 
     static native int EVP_HPKE_CTX_max_overhead(long ctx);
 
@@ -120,6 +122,12 @@ final class BoringSSL {
 
     static native int EVP_AEAD_CTX_open(
             long ctx, long out, int max_out_len, long nonce, int nonce_len, long in, int in_len, long ad, int ad_len);
+
+    static native long EVP_HPKE_KDF_hkdf_md(long kdf);
+
+    static native byte[] HKDF_extract(long digest, byte[] secret, byte[] salt);
+
+    static native byte[] HKDF_expand(long digest, int out_len, byte[] prk, byte[] info);
 
     static long memory_address(ByteBuf buffer) {
         if (buffer.hasMemoryAddress()) {

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSL.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSL.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.hpke.boringssl;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.internal.ClassInitializerUtil;
+import io.netty.util.internal.NativeLibraryLoader;
+import io.netty.util.internal.PlatformDependent;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+final class BoringSSL {
+
+    static {
+        // Preload all classes that will be used in the OnLoad(...) function of JNI to eliminate the possiblity of a
+        // class-loader deadlock. This is a workaround for https://github.com/netty/netty/issues/11209.
+
+        // This needs to match all the classes that are loaded via NETTY_JNI_UTIL_LOAD_CLASS or looked up via
+        // NETTY_JNI_UTIL_FIND_CLASS.
+        ClassInitializerUtil.tryLoadClasses(BoringSSL.class);
+
+        try {
+            // First, try calling a side-effect free JNI method to see if the library was already
+            // loaded by the application.
+            BoringSSLNativeStaticallyReferencedJniMethods.EVP_hpke_x25519_hkdf_sha256();
+        } catch (UnsatisfiedLinkError ignore) {
+            // The library was not previously loaded, load it now.
+            loadNativeLibrary();
+        }
+    }
+
+    private static void loadNativeLibrary() {
+        // This needs to be kept in sync with what is defined in netty_incubator_codec_ohttp_hpke_boringssl.c
+        String libName = "netty_incubator_codec_ohttp_hpke_boringssl";
+        ClassLoader cl = PlatformDependent.getClassLoader(BoringSSL.class);
+
+        if (!PlatformDependent.isAndroid()) {
+            libName += '_' + PlatformDependent.normalizedOs()
+                    + '_' + PlatformDependent.normalizedArch();
+        }
+
+        try {
+            NativeLibraryLoader.load(libName, cl);
+        } catch (UnsatisfiedLinkError e) {
+            throw e;
+        }
+    }
+
+    static final long EVP_hpke_x25519_hkdf_sha256 =
+            BoringSSLNativeStaticallyReferencedJniMethods.EVP_hpke_x25519_hkdf_sha256();
+    static final long EVP_hpke_hkdf_sha256 =
+            BoringSSLNativeStaticallyReferencedJniMethods.EVP_hpke_hkdf_sha256();
+    static final long EVP_hpke_aes_128_gcm =
+            BoringSSLNativeStaticallyReferencedJniMethods.EVP_hpke_aes_128_gcm();
+    static final long EVP_hpke_aes_256_gcm =
+            BoringSSLNativeStaticallyReferencedJniMethods.EVP_hpke_aes_256_gcm();
+    static final long EVP_hpke_chacha20_poly1305 =
+            BoringSSLNativeStaticallyReferencedJniMethods.EVP_hpke_chacha20_poly1305();
+
+    static final int EVP_AEAD_DEFAULT_TAG_LENGTH =
+            BoringSSLNativeStaticallyReferencedJniMethods.EVP_AEAD_DEFAULT_TAG_LENGTH();
+
+    static native long EVP_HPKE_CTX_new();
+    static native long EVP_HPKE_CTX_cleanup(long ctx);
+    static native long EVP_HPKE_CTX_free(long ctx);
+
+    // TODO: Do we also need the auth methods ?
+    static native byte[] EVP_HPKE_CTX_setup_sender(
+            long ctx, long kem, long kdf, long aead, byte[] peer_public_key, byte[] info);
+    static native byte[] EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
+            long ctx, long kem, long kdf, long aead, byte[] peer_public_key, byte[] info, byte[] seed);
+    static native int EVP_HPKE_CTX_setup_recipient(
+            long ctx, long key, long kdf, long aead, byte[] enc, byte[] info);
+
+    static native int EVP_HPKE_CTX_open(
+            long ctx, long out, int max_out_len, long in, int in_len, long ad, int ad_len);
+    static native int EVP_HPKE_CTX_seal(
+            long ctx, long out, int max_out_len, long in, int in_len, long ad, int ad_len);
+    static native int EVP_HPKE_CTX_export(
+            long ctx, long out, int secret_len, long context, int context_len);
+
+    static native int EVP_HPKE_CTX_max_overhead(long ctx);
+
+    static native long EVP_HPKE_KEY_new();
+    static native void EVP_HPKE_KEY_free(long key);
+    static native void EVP_HPKE_KEY_cleanup(long key);
+
+    static native int EVP_HPKE_KEY_init(long key, long kem, byte[] priv_key);
+    static native byte[] EVP_HPKE_KEY_public_key(long key);
+    static native byte[] EVP_HPKE_KEY_private_key(long key);
+
+    static native int EVP_HPKE_KEM_public_key_len(long kem);
+
+    static native long memory_address(ByteBuffer buffer);
+
+    static native int EVP_AEAD_key_length(long aead);
+    static native int EVP_AEAD_nonce_length(long aead);
+    static native int EVP_AEAD_max_overhead(long aead);
+    static native int EVP_AEAD_max_tag_len(long aead);
+
+    static native long EVP_AEAD_CTX_new(long aead, byte[] key, int tag_len);
+    static native void EVP_AEAD_CTX_cleanup(long ctx);
+    static native void EVP_AEAD_CTX_free(long ctx);
+
+    static native int EVP_AEAD_CTX_seal(
+            long ctx, long out, int max_out_len, long nonce, int nonce_len, long in, int in_len, long ad, int ad_len);
+
+    static native int EVP_AEAD_CTX_open(
+            long ctx, long out, int max_out_len, long nonce, int nonce_len, long in, int in_len, long ad, int ad_len);
+
+    static long memory_address(ByteBuf buffer) {
+        if (buffer.hasMemoryAddress()) {
+            return buffer.memoryAddress();
+        }
+        return memory_address(buffer.internalNioBuffer(0, buffer.capacity()));
+    }
+
+    static long EVP_HPKE_CTX_new_or_throw() {
+        long ctx = BoringSSL.EVP_HPKE_CTX_new();
+        if (ctx == -1) {
+            throw new IllegalStateException("Unable to allocate EVP_HPKE_CTX");
+        }
+        return ctx;
+    }
+
+    static void EVP_HPKE_CTX_cleanup_and_free(long ctx) {
+        if (ctx != -1) {
+            BoringSSL.EVP_HPKE_CTX_cleanup(ctx);
+            BoringSSL.EVP_HPKE_CTX_free(ctx);
+        }
+    }
+
+    static long EVP_HPKE_KEY_new_or_throw() {
+        long key = BoringSSL.EVP_HPKE_KEY_new();
+        if (key == -1) {
+            throw new IllegalStateException("Unable to allocate EVP_HPKE_KEY");
+        }
+        return key;
+    }
+
+    static long EVP_HPKE_KEY_new_and_init_or_throw(long kem, byte[] privateKeyBytes) {
+        long key = EVP_HPKE_KEY_new_or_throw();
+        EVP_HPKE_KEY_init_or_throw(key, kem, privateKeyBytes);
+        return key;
+    }
+
+    static void EVP_HPKE_KEY_init_or_throw(long key, long kem, byte[] privateKeyBytes) {
+        if (BoringSSL.EVP_HPKE_KEY_init(key, kem, privateKeyBytes) != 1) {
+            throw new IllegalArgumentException(
+                    "privateKeyBytes does not contain a valid private key: " + Arrays.toString(privateKeyBytes));
+        }
+    }
+
+    static void EVP_HPKE_KEY_cleanup_and_free(long key) {
+        if (key != -1) {
+            BoringSSL.EVP_HPKE_KEY_cleanup(key);
+            BoringSSL.EVP_HPKE_KEY_free(key);
+        }
+    }
+
+    static long EVP_AEAD_CTX_new_or_throw(long aead, byte[] key, int tagLen) {
+        long ctx = BoringSSL.EVP_AEAD_CTX_new(aead, key, tagLen);
+        if (ctx == -1) {
+            throw new IllegalStateException("Unable to allocate EVP_AEAD_CTX");
+        }
+        return ctx;
+    }
+
+    static void EVP_AEAD_CTX_cleanup_and_free(long ctx) {
+        if (ctx != -1) {
+            BoringSSL.EVP_AEAD_CTX_cleanup(ctx);
+            BoringSSL.EVP_AEAD_CTX_free(ctx);
+        }
+    }
+}
+
+

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAEADContext.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAEADContext.java
@@ -20,6 +20,9 @@ import io.netty.buffer.Unpooled;
 import io.netty.incubator.codec.hpke.AEADContext;
 import io.netty.incubator.codec.hpke.CryptoException;
 
+/**
+ * BoringSSL based implementation of an {@link AEADContext}.
+ */
 final class BoringSSLAEADContext extends BoringSSLCryptoContext implements AEADContext {
 
     private final ByteBuf baseNonce;

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAEADContext.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAEADContext.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.hpke.boringssl;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.incubator.codec.hpke.AEADContext;
+import io.netty.incubator.codec.hpke.CryptoException;
+
+final class BoringSSLAEADContext extends BoringSSLCryptoContext implements AEADContext {
+
+    private final ByteBuf baseNonce;
+    private final long baseNonceAddress;
+    private final int baseNonceLen;
+    private final int AEAD_max_overhead;
+
+    private final BoringSSLCryptoOperation seal = new BoringSSLCryptoOperation() {
+        @Override
+        int maxOutLen(long ctx, int inReadable) {
+            return AEAD_max_overhead + inReadable;
+        }
+
+        @Override
+        int execute(long ctx, long ad, int adLen, long in, int inLen, long out, int outLen) {
+            return BoringSSL.EVP_AEAD_CTX_seal(ctx, out, outLen, baseNonceAddress, baseNonceLen, in, inLen, ad, adLen);
+        }
+    };
+
+    private final BoringSSLCryptoOperation open = new BoringSSLCryptoOperation() {
+        @Override
+        int maxOutLen(long ctx, int inReadable) {
+            return inReadable;
+        }
+
+        @Override
+        int execute(long ctx, long ad, int adLen, long in, int inLen, long out, int outLen) {
+            return BoringSSL.EVP_AEAD_CTX_open(ctx, out, outLen, baseNonceAddress, baseNonceLen, in, inLen, ad, adLen);
+        }
+    };
+
+    BoringSSLAEADContext(long ctx, int AEAD_max_overhead, byte[] baseNonce) {
+        super(ctx);
+        this.baseNonce = Unpooled.directBuffer(baseNonce.length).writeBytes(baseNonce);
+        this.baseNonceAddress = BoringSSL.memory_address(this.baseNonce);
+        this.baseNonceLen = this.baseNonce.readableBytes();
+        this.AEAD_max_overhead = AEAD_max_overhead;
+    }
+
+    @Override
+    protected void destroyCtx(long ctx) {
+        baseNonce.release();
+        BoringSSL.EVP_AEAD_CTX_cleanup_and_free(ctx);
+    }
+
+    @Override
+    public void open(ByteBuf aad, ByteBuf ct, ByteBuf out) throws CryptoException {
+        if (!open.execute(checkClosedAndReturnCtx(), aad, ct, out)) {
+            throw new CryptoException("open(...) failed");
+        }
+    }
+
+    @Override
+    public void seal(ByteBuf aad, ByteBuf pt, ByteBuf out) throws CryptoException {
+        if (!seal.execute(checkClosedAndReturnCtx(), aad, pt, out)) {
+            throw new CryptoException("seal(...) failed");
+        }
+    }
+}

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAEADContext.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAEADContext.java
@@ -28,12 +28,12 @@ final class BoringSSLAEADContext extends BoringSSLCryptoContext implements AEADC
     private final ByteBuf baseNonce;
     private final long baseNonceAddress;
     private final int baseNonceLen;
-    private final int AEAD_max_overhead;
+    private final int aeadMaxOverhead;
 
     private final BoringSSLCryptoOperation seal = new BoringSSLCryptoOperation() {
         @Override
         int maxOutLen(long ctx, int inReadable) {
-            return AEAD_max_overhead + inReadable;
+            return aeadMaxOverhead + inReadable;
         }
 
         @Override
@@ -54,12 +54,12 @@ final class BoringSSLAEADContext extends BoringSSLCryptoContext implements AEADC
         }
     };
 
-    BoringSSLAEADContext(long ctx, int AEAD_max_overhead, byte[] baseNonce) {
+    BoringSSLAEADContext(long ctx, int aeadMaxOverhead, byte[] baseNonce) {
         super(ctx);
         this.baseNonce = Unpooled.directBuffer(baseNonce.length).writeBytes(baseNonce);
         this.baseNonceAddress = BoringSSL.memory_address(this.baseNonce);
         this.baseNonceLen = this.baseNonce.readableBytes();
-        this.AEAD_max_overhead = AEAD_max_overhead;
+        this.aeadMaxOverhead = aeadMaxOverhead;
     }
 
     @Override

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAsymmetricCipherKeyPair.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAsymmetricCipherKeyPair.java
@@ -60,5 +60,13 @@ final class BoringSSLAsymmetricCipherKeyPair implements AsymmetricCipherKeyPair 
         result = 31 * result + publicKey.hashCode();
         return result;
     }
+
+    @Override
+    public String toString() {
+        return "BoringSSLAsymmetricCipherKeyPair{" +
+                "privateKey=" + privateKey +
+                ", publicKey=" + publicKey +
+                '}';
+    }
 }
 

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAsymmetricCipherKeyPair.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAsymmetricCipherKeyPair.java
@@ -20,7 +20,6 @@ import io.netty.incubator.codec.hpke.AsymmetricKeyParameter;
 
 // TODO: Maybe expose sub-type which is ReferenceCounted and so allows to take ownership of EVP_HPKE_KEY.
 final class BoringSSLAsymmetricCipherKeyPair implements AsymmetricCipherKeyPair {
-
     private final BoringSSLAsymmetricKeyParameter privateKey;
     private final BoringSSLAsymmetricKeyParameter publicKey;
 

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAsymmetricCipherKeyPair.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAsymmetricCipherKeyPair.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.hpke.boringssl;
+
+import io.netty.incubator.codec.hpke.AsymmetricCipherKeyPair;
+import io.netty.incubator.codec.hpke.AsymmetricKeyParameter;
+
+// TODO: Maybe expose sub-type which is ReferenceCounted and so allows to take ownership of EVP_HPKE_KEY.
+final class BoringSSLAsymmetricCipherKeyPair implements AsymmetricCipherKeyPair {
+
+    private final BoringSSLAsymmetricKeyParameter privateKey;
+    private final BoringSSLAsymmetricKeyParameter publicKey;
+
+    BoringSSLAsymmetricCipherKeyPair(byte[] privateKeyBytes, byte[] publicKeyBytes) {
+        privateKey = new BoringSSLAsymmetricKeyParameter(privateKeyBytes, true);
+        publicKey = new BoringSSLAsymmetricKeyParameter(publicKeyBytes, false);
+    }
+
+    @Override
+    public BoringSSLAsymmetricKeyParameter publicParameters() {
+        return publicKey;
+    }
+
+    @Override
+    public BoringSSLAsymmetricKeyParameter privateParameters() {
+        return privateKey;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        BoringSSLAsymmetricCipherKeyPair that = (BoringSSLAsymmetricCipherKeyPair) o;
+        if (!privateKey.equals(that.privateKey)) {
+            return false;
+        }
+        return publicKey.equals(that.publicKey);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = privateKey.hashCode();
+        result = 31 * result + publicKey.hashCode();
+        return result;
+    }
+}
+

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAsymmetricKeyParameter.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAsymmetricKeyParameter.java
@@ -61,4 +61,12 @@ final class BoringSSLAsymmetricKeyParameter implements AsymmetricKeyParameter {
         result = 31 * result + (isPrivate ? 1 : 0);
         return result;
     }
+
+    @Override
+    public String toString() {
+        return "BoringSSLAsymmetricKeyParameter{" +
+                "bytes=" + Arrays.toString(bytes) +
+                ", isPrivate=" + isPrivate +
+                '}';
+    }
 }

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAsymmetricKeyParameter.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAsymmetricKeyParameter.java
@@ -20,7 +20,7 @@ import io.netty.incubator.codec.hpke.AsymmetricKeyParameter;
 import java.util.Arrays;
 
 final class BoringSSLAsymmetricKeyParameter implements AsymmetricKeyParameter {
-
+    // Package-private so we can access it without doing a clone().
     final byte[] bytes;
     private final boolean isPrivate;
 

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAsymmetricKeyParameter.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAsymmetricKeyParameter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.hpke.boringssl;
+
+import io.netty.incubator.codec.hpke.AsymmetricKeyParameter;
+
+import java.util.Arrays;
+
+final class BoringSSLAsymmetricKeyParameter implements AsymmetricKeyParameter {
+
+    final byte[] bytes;
+    private final boolean isPrivate;
+
+    BoringSSLAsymmetricKeyParameter(byte[] bytes, boolean isPrivate) {
+        this.bytes = bytes;
+        this.isPrivate = isPrivate;
+    }
+
+    @Override
+    public byte[] encoded() {
+        return bytes.clone();
+    }
+
+    @Override
+    public boolean isPrivate() {
+        return isPrivate;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)  {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        BoringSSLAsymmetricKeyParameter that = (BoringSSLAsymmetricKeyParameter) o;
+        if (isPrivate != that.isPrivate) {
+            return false;
+        }
+        return Arrays.equals(bytes, that.bytes);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(bytes);
+        result = 31 * result + (isPrivate ? 1 : 0);
+        return result;
+    }
+}

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLCryptoContext.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLCryptoContext.java
@@ -31,6 +31,13 @@ abstract class BoringSSLCryptoContext implements CryptoContext {
         assert ctx != -1;
         this.ctxRef = new AtomicLong(ctx);
     }
+
+    /**
+     * Returns the native {@code *_CTX} pointer or throws a {@link IllegalStateException} if the context was
+     * already closed.
+     *
+     * @return context
+     */
     protected final long checkClosedAndReturnCtx() {
         long ctx = ctxRef.get();
         if (ctx == -1) {
@@ -46,6 +53,11 @@ abstract class BoringSSLCryptoContext implements CryptoContext {
            destroyCtx(ctx);
        }
     }
-    
+
+    /**
+     * Destroy the native {@code *_CTX} pointer.
+     *
+     * @param ctx   context.
+     */
     protected abstract void destroyCtx(long ctx);
 }

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLCryptoContext.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLCryptoContext.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.hpke.boringssl;
+
+import io.netty.incubator.codec.hpke.CryptoContext;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Abstract base class for BoringSSL based {@link CryptoContext}.
+ */
+abstract class BoringSSLCryptoContext implements CryptoContext {
+
+    // We use an AtomicLong to reduce the possibility of crashing after the user called close().
+    private final AtomicLong ctxRef;
+
+    BoringSSLCryptoContext(long ctx) {
+        assert ctx != -1;
+        this.ctxRef = new AtomicLong(ctx);
+    }
+    protected final long checkClosedAndReturnCtx() {
+        long ctx = ctxRef.get();
+        if (ctx == -1) {
+            throw new IllegalStateException(getClass().getSimpleName() + " closed");
+        }
+        return ctx;
+    }
+
+    @Override
+    public final void close()  {
+       long ctx = ctxRef.getAndSet(-1);
+       if (ctx != -1) {
+           destroyCtx(ctx);
+       }
+    }
+    
+    protected abstract void destroyCtx(long ctx);
+}

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLCryptoOperation.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLCryptoOperation.java
@@ -27,7 +27,7 @@ abstract class BoringSSLCryptoOperation {
      * If successfully the {@link ByteBuf#readerIndex()} and {@link ByteBuf#writerIndex()} will be adjusted
      * accordingly.
      *
-     * @param ctx   the native *_CTX pointer.
+     * @param ctx   the native {@code *_CTX} pointer.
      * @param aad   the AAD buffer.
      * @param in    the input data.
      * @param out   the buffer for writing into.

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLCryptoOperation.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLCryptoOperation.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.hpke.boringssl;
+
+import io.netty.buffer.ByteBuf;
+
+abstract class BoringSSLCryptoOperation {
+
+    final boolean execute(long ctx, ByteBuf aad, ByteBuf in, ByteBuf out) {
+        ByteBuf directAad = null;
+        ByteBuf directIn = null;
+        ByteBuf directOut = null;
+        try {
+            directAad = directReadable(aad);
+            directIn = directReadable(in);
+
+            int maxOutLen = maxOutLen(ctx, in.readableBytes());
+            directOut = directWritable(out, maxOutLen);
+
+            long directAadAddress = BoringSSL.memory_address(directAad) + directAad.readerIndex();
+            int directAddReadableBytes = directAad.readableBytes();
+            long directInAddress = BoringSSL.memory_address(directIn) + directIn.readerIndex();
+            int directInReadableBytes = directIn.readableBytes();
+            long directOutAddress = BoringSSL.memory_address(directOut) + directOut.writerIndex();
+            int directOutWritableBytes = directOut.writableBytes();
+            int result = execute(ctx, directAadAddress, directAddReadableBytes,
+                    directInAddress, directInReadableBytes,
+                    directOutAddress, directOutWritableBytes);
+            if (result <= 0) {
+                return false;
+            }
+            aad.skipBytes(directAddReadableBytes);
+            in.skipBytes(directInReadableBytes);
+            // Move the writerIndex.
+            directOut.writerIndex(directOut.writerIndex() + result);
+            if (out != directOut) {
+                // If we allocated a temporary buffer we need to also copy over the result.
+                out.writeBytes(directOut);
+            }
+            return true;
+        } finally {
+            // Release temporary copies if any.
+            releaseIfNotTheSameInstance(aad, directAad);
+            releaseIfNotTheSameInstance(in, directIn);
+            releaseIfNotTheSameInstance(out, directOut);
+        }
+    }
+
+    abstract int maxOutLen(long ctx, int inReadable);
+
+    abstract int execute(long ctx, long ad, int adLen, long in, int inLen, long out, int outLen);
+
+    private static ByteBuf directReadable(ByteBuf in) {
+        if (in.isDirect()) {
+            return in;
+        }
+        ByteBuf directIn = in.alloc().directBuffer(in.readableBytes());
+        directIn.writeBytes(in, in.readerIndex(), in.readableBytes());
+        return directIn;
+    }
+
+    private static ByteBuf directWritable(ByteBuf out, int minWritable) {
+        if (out.isDirect()) {
+            out.ensureWritable(minWritable);
+            return out;
+        }
+        return out.alloc().directBuffer(minWritable);
+    }
+
+    private static void releaseIfNotTheSameInstance(ByteBuf buf, ByteBuf maybeOther) {
+        if (maybeOther != null && maybeOther != buf) {
+            maybeOther.release();
+        }
+    }
+}

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLCryptoOperation.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLCryptoOperation.java
@@ -17,8 +17,22 @@ package io.netty.incubator.codec.hpke.boringssl;
 
 import io.netty.buffer.ByteBuf;
 
+/**
+ * Abstract base class to perform native crypto operations via BoringSSL.
+ */
 abstract class BoringSSLCryptoOperation {
 
+    /**
+     * Executes a crypto related function and returns {@code true} if successful, {@code false} otherwise.
+     * If successfully the {@link ByteBuf#readerIndex()} and {@link ByteBuf#writerIndex()} will be adjusted
+     * accordingly.
+     *
+     * @param ctx   the native *_CTX pointer.
+     * @param aad   the AAD buffer.
+     * @param in    the input data.
+     * @param out   the buffer for writing into.
+     * @return      {@code true} if successful, {@code false} otherwise.
+     */
     final boolean execute(long ctx, ByteBuf aad, ByteBuf in, ByteBuf out) {
         ByteBuf directAad = null;
         ByteBuf directIn = null;

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKE.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKE.java
@@ -15,6 +15,9 @@
  */
 package io.netty.incubator.codec.hpke.boringssl;
 
+/**
+ * Helper class to check if the native BoringSSL based crypto can be used.
+ */
 public final class BoringSSLHPKE {
 
     @SuppressWarnings("unchecked")

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKE.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKE.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.hpke.boringssl;
+
+public final class BoringSSLHPKE {
+
+    @SuppressWarnings("unchecked")
+    private static final Throwable UNAVAILABILITY_CAUSE;
+
+    static {
+        Throwable cause = null;
+
+        try {
+            long ctx = BoringSSL.EVP_HPKE_KEY_new();
+            BoringSSL.EVP_HPKE_CTX_cleanup_and_free(ctx);
+        } catch (Throwable error) {
+            cause = error;
+        }
+
+        UNAVAILABILITY_CAUSE = cause;
+    }
+
+    /**
+     * Returns {@code true} if and only if the HPKE implementation is usable on the running platform is available.
+     *
+     * @return {@code true} if this HPKE implementation can be used on the current platform, {@code false} otherwise.
+     */
+    public static boolean isAvailable() {
+        return UNAVAILABILITY_CAUSE == null;
+    }
+
+    /**
+     * Ensure that HPKE implementation is usable on the running platform is available.
+     *
+     * @throws UnsatisfiedLinkError if unavailable
+     */
+    public static void ensureAvailability() {
+        if (UNAVAILABILITY_CAUSE != null) {
+            throw (Error) new UnsatisfiedLinkError(
+                    "failed to load the required native library").initCause(UNAVAILABILITY_CAUSE);
+        }
+    }
+
+    /**
+     * Returns the cause of unavailability.
+     *
+     * @return the cause if unavailable. {@code null} if available.
+     */
+    public static Throwable unavailabilityCause() {
+        return UNAVAILABILITY_CAUSE;
+    }
+}

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKEContext.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKEContext.java
@@ -29,22 +29,25 @@ class BoringSSLHPKEContext extends BoringSSLCryptoContext implements HPKEContext
     @Override
     public final byte[] export(byte[] exportContext, int length) {
         long ctx = checkClosedAndReturnCtx();
-        // TODO: implement me
-        throw new UnsupportedOperationException();
+        return BoringSSL.EVP_HPKE_CTX_export(ctx, length, exportContext);
     }
 
     @Override
     public final byte[] extract(byte[] salt, byte[] ikm) {
-        long ctx = checkClosedAndReturnCtx();
-        // TODO: implement me
-        throw new UnsupportedOperationException();
+        long digest = boringSSLDigest();
+        return BoringSSL.HKDF_extract(digest, ikm, salt);
     }
 
     @Override
     public final byte[] expand(byte[] prk, byte[] info, int length) {
+        long digest = boringSSLDigest();
+        return BoringSSL.HKDF_expand(digest, length, prk, info);
+    }
+
+    private long boringSSLDigest() {
         long ctx = checkClosedAndReturnCtx();
-        // TODO: implement me
-        throw new UnsupportedOperationException();
+        long kdf = BoringSSL.EVP_HPKE_CTX_kdf(ctx);
+        return BoringSSL.EVP_HPKE_KDF_hkdf_md(kdf);
     }
 
     @Override

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKEContext.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKEContext.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.hpke.boringssl;
+
+import io.netty.incubator.codec.hpke.HPKEContext;
+
+/**
+ * BoringSSL based {@link HPKEContext}.
+ */
+class BoringSSLHPKEContext extends BoringSSLCryptoContext implements HPKEContext {
+
+    BoringSSLHPKEContext(long hpkeCtx) {
+        super(hpkeCtx);
+    }
+
+    @Override
+    public final byte[] export(byte[] exportContext, int length) {
+        long ctx = checkClosedAndReturnCtx();
+        // TODO: implement me
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public final byte[] extract(byte[] salt, byte[] ikm) {
+        long ctx = checkClosedAndReturnCtx();
+        // TODO: implement me
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public final byte[] expand(byte[] prk, byte[] info, int length) {
+        long ctx = checkClosedAndReturnCtx();
+        // TODO: implement me
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected final void destroyCtx(long ctx) {
+        BoringSSL.EVP_HPKE_CTX_cleanup_and_free(ctx);
+    }
+}

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKERecipientContext.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKERecipientContext.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.hpke.boringssl;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.incubator.codec.hpke.CryptoException;
+import io.netty.incubator.codec.hpke.HPKERecipientContext;
+
+/**
+ * BoringSSL based {@link HPKERecipientContext}.
+ */
+final class BoringSSLHPKERecipientContext extends BoringSSLHPKEContext implements HPKERecipientContext {
+    // See https://github.com/google/boringssl/blob/ac45226f8d8223d70ed37cf81df5f03aea1d533c/include/openssl/hpke.h#L290
+    private static final BoringSSLCryptoOperation OPEN = new BoringSSLCryptoOperation() {
+        @Override
+        int maxOutLen(long ctx, int inReadable) {
+            return inReadable;
+        }
+
+        @Override
+        int execute(long ctx, long ad, int adLen, long in, int inLen, long out, int outLen) {
+            return BoringSSL.EVP_HPKE_CTX_open(ctx, out, outLen, in, inLen, ad, adLen);
+        }
+    };
+
+    BoringSSLHPKERecipientContext(long hpkeCtx) {
+        super(hpkeCtx);
+    }
+
+    @Override
+    public void open(ByteBuf aad, ByteBuf ct, ByteBuf out) throws CryptoException {
+        if (!OPEN.execute(checkClosedAndReturnCtx(), aad, ct, out)) {
+            throw new CryptoException("open(...) failed");
+        }
+    }
+}

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKESenderContext.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKESenderContext.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.hpke.boringssl;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.incubator.codec.hpke.CryptoException;
+import io.netty.incubator.codec.hpke.HPKERecipientContext;
+import io.netty.incubator.codec.hpke.HPKESenderContext;
+
+/**
+ * BoringSSL based {@link HPKESenderContext}.
+ */
+final class BoringSSLHPKESenderContext extends BoringSSLHPKEContext
+        implements HPKESenderContext {
+
+    // See https://github.com/google/boringssl/blob/ac45226f8d8223d70ed37cf81df5f03aea1d533c/include/openssl/hpke.h#L303
+    private static final BoringSSLCryptoOperation SEAL = new BoringSSLCryptoOperation() {
+        @Override
+        int maxOutLen(long ctx, int inReadable) {
+            return BoringSSL.EVP_HPKE_CTX_max_overhead(ctx) + inReadable;
+        }
+
+        @Override
+        int execute(long ctx, long ad, int adLen, long in, int inLen, long out, int outLen) {
+            return BoringSSL.EVP_HPKE_CTX_seal(ctx, out, outLen, in, inLen, ad, adLen);
+        }
+    };
+
+    private final byte[] encapsulation;
+
+    BoringSSLHPKESenderContext(long hpkeCtx, byte[] encapsulation) {
+        super(hpkeCtx);
+        this.encapsulation = encapsulation;
+    }
+
+    @Override
+    public byte[] encapsulation() {
+        return encapsulation.clone();
+    }
+
+    @Override
+    public void seal(ByteBuf aad, ByteBuf pt, ByteBuf out) throws CryptoException {
+        if (!SEAL.execute(checkClosedAndReturnCtx(), aad, pt, out)) {
+            throw new CryptoException("seal(...) failed");
+        }
+    }
+}

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLNativeStaticallyReferencedJniMethods.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLNativeStaticallyReferencedJniMethods.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.hpke.boringssl;
+
+final class BoringSSLNativeStaticallyReferencedJniMethods {
+    static native long EVP_hpke_x25519_hkdf_sha256();
+    static native long EVP_hpke_hkdf_sha256();
+    static native long EVP_hpke_aes_128_gcm();
+    static native long EVP_hpke_aes_256_gcm();
+    static native long EVP_hpke_chacha20_poly1305();
+    static native int EVP_AEAD_DEFAULT_TAG_LENGTH();
+
+    private BoringSSLNativeStaticallyReferencedJniMethods() { }
+}

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLNativeStaticallyReferencedJniMethods.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLNativeStaticallyReferencedJniMethods.java
@@ -21,6 +21,11 @@ final class BoringSSLNativeStaticallyReferencedJniMethods {
     static native long EVP_hpke_aes_128_gcm();
     static native long EVP_hpke_aes_256_gcm();
     static native long EVP_hpke_chacha20_poly1305();
+
+    static native long EVP_aead_aes_128_gcm();
+    static native long EVP_aead_aes_256_gcm();
+    static native long EVP_aead_chacha20_poly1305();
+
     static native int EVP_AEAD_DEFAULT_TAG_LENGTH();
 
     private BoringSSLNativeStaticallyReferencedJniMethods() { }

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLOHttpCryptoProvider.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLOHttpCryptoProvider.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.hpke.boringssl;
+
+
+import io.netty.incubator.codec.hpke.AEADContext;
+import io.netty.incubator.codec.hpke.AsymmetricCipherKeyPair;
+import io.netty.incubator.codec.hpke.AsymmetricKeyParameter;
+import io.netty.incubator.codec.hpke.HPKERecipientContext;
+import io.netty.incubator.codec.hpke.HPKESenderContext;
+import io.netty.incubator.codec.hpke.OHttpCryptoProvider;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * BoringSSL based {@link OHttpCryptoProvider}. {@link BoringSSLHPKE#ensureAvailability()} or
+ * {@link BoringSSLHPKE#isAvailable()} should be used before accessing {@link #INSTANCE} to ensure
+ * the native library can be loaded on the used platform.
+ */
+public final class BoringSSLOHttpCryptoProvider implements OHttpCryptoProvider {
+
+    private static final List<AEAD> SUPPORTED_AEAD_LIST = Collections.unmodifiableList(Arrays.asList(AEAD.values()));
+    private static final List<Mode> SUPPORTED_MODE_LIST = Collections.singletonList(Mode.Base);
+    private static final List<KEM> SUPPORTED_KEM_LIST = Collections.singletonList(KEM.X25519_SHA256);
+    private static final List<KDF> SUPPORTED_KDF_LIST = Collections.singletonList(KDF.HKDF_SHA256);
+
+    public static final BoringSSLOHttpCryptoProvider INSTANCE = new BoringSSLOHttpCryptoProvider();
+
+    private BoringSSLOHttpCryptoProvider() { }
+
+    @Override
+    public AEADContext setupAEAD(AEAD aead, byte[] key, byte[] baseNonce) {
+        long boringSSLAead = boringSSLAEAD(aead);
+        int keyLength = BoringSSL.EVP_AEAD_key_length(boringSSLAead);
+        if (keyLength != key.length) {
+            throw new IllegalArgumentException("key length must be: " + keyLength);
+        }
+        int nounceLength = BoringSSL.EVP_AEAD_nonce_length(boringSSLAead);
+        if (nounceLength != baseNonce.length) {
+            throw new IllegalArgumentException("baseNonce length must be: " + nounceLength);
+        }
+
+        int maxOverhead = BoringSSL.EVP_AEAD_max_overhead(boringSSLAead);
+        long ctx = BoringSSL.EVP_AEAD_CTX_new_or_throw(boringSSLAead, key, BoringSSL.EVP_AEAD_DEFAULT_TAG_LENGTH);
+        try {
+            BoringSSLAEADContext aeadCtx = new BoringSSLAEADContext(ctx, maxOverhead, baseNonce);
+            ctx = -1;
+            return aeadCtx;
+        } finally {
+            if (ctx != -1) {
+                BoringSSL.EVP_AEAD_CTX_cleanup_and_free(ctx);
+            }
+        }
+    }
+
+    private static long boringSSLKDF(KDF kdf) {
+        if (kdf != KDF.HKDF_SHA256) {
+            throw new IllegalArgumentException("KDF not supported: "+ kdf);
+        }
+        return BoringSSL.EVP_hpke_hkdf_sha256;
+    }
+
+    private static long boringSSLKEM(KEM kem) {
+        if (kem != KEM.X25519_SHA256) {
+            throw new IllegalArgumentException("KEM not supported: "+ kem);
+        }
+        return BoringSSL.EVP_hpke_x25519_hkdf_sha256;
+    }
+
+    private static long boringSSLAEAD(AEAD aead) {
+        switch (aead) {
+            case AES_GCM128:
+                return BoringSSL.EVP_hpke_aes_128_gcm;
+            case AES_GCM256:
+                return BoringSSL.EVP_hpke_aes_256_gcm;
+            case CHACHA20_POLY1305:
+                return BoringSSL.EVP_hpke_chacha20_poly1305;
+            default:
+                throw new IllegalArgumentException("AEAD not supported: " + aead);
+        }
+    }
+
+    private static void validateMode(Mode mode) {
+        // TODO: Also support AUTH
+        if (mode != Mode.Base) {
+            throw new IllegalArgumentException("Mode not supported: " + mode);
+        }
+    }
+
+    @Override
+    public HPKESenderContext setupHPKEBaseS(
+            Mode mode, KEM kem, KDF kdf, AEAD aead, AsymmetricKeyParameter pkR,
+            byte[] info, AsymmetricCipherKeyPair kpE) {
+        validateMode(mode);
+        long boringSSLKem = boringSSLKEM(kem);
+        long boringSSLKdf = boringSSLKDF(kdf);
+        long boringSSLAead = boringSSLAEAD(aead);
+        final byte[] pkRBytes = encodedAsymmetricKeyParameter(pkR);
+        final byte[] encapsulation;
+        long ctx = BoringSSL.EVP_HPKE_CTX_new_or_throw();
+        try {
+            if (kpE == null) {
+                encapsulation = BoringSSL.EVP_HPKE_CTX_setup_sender(
+                        ctx, boringSSLKem, boringSSLKdf, boringSSLAead, pkRBytes, info);
+            } else {
+                encapsulation = BoringSSL.EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
+                        ctx, boringSSLKem, boringSSLKdf, boringSSLAead, pkRBytes, info,
+                        // As we only support X25519 it is the right thing to just use the private key as seed.
+                        // See https://github.com/google/boringssl/blob/master/include/openssl/hpke.h#L235C44-L235C50
+                        encodedAsymmetricKeyParameter(kpE.privateParameters()));
+            }
+            if (encapsulation == null) {
+                throw new IllegalStateException("Unable to init EVP_HPKE_CTX");
+            }
+            BoringSSLHPKESenderContext hpkeCtx =
+                    new BoringSSLHPKESenderContext(ctx, encapsulation);
+            ctx = -1;
+            return hpkeCtx;
+        } finally {
+            if (ctx != -1) {
+                BoringSSL.EVP_HPKE_CTX_cleanup_and_free(ctx);
+            }
+        }
+    }
+
+    private static byte[] encodedAsymmetricKeyParameter(AsymmetricKeyParameter parameter) {
+        if (parameter instanceof BoringSSLAsymmetricKeyParameter) {
+            // No copy needed.
+            return ((BoringSSLAsymmetricKeyParameter) parameter).bytes;
+        }
+        return parameter.encoded();
+    }
+
+    @Override
+    public HPKERecipientContext setupHPKEBaseR(Mode mode, KEM kem, KDF kdf, AEAD aead, byte[] enc,
+                                               AsymmetricCipherKeyPair skR, byte[] info) {
+        validateMode(mode);
+        // Validate that KEM is supported by BoringSSL
+        long boringSSLKem = boringSSLKEM(kem);
+        long boringSSLKdf = boringSSLKDF(kdf);
+        long boringSSLAead = boringSSLAEAD(aead);
+
+        long ctx = -1;
+        long key = -1;
+        try {
+            byte[] privateKeyBytes = encodedAsymmetricKeyParameter(skR.privateParameters());
+            key = BoringSSL.EVP_HPKE_KEY_new_and_init_or_throw(boringSSLKem, privateKeyBytes);
+            ctx = BoringSSL.EVP_HPKE_CTX_new_or_throw();
+            if (BoringSSL.EVP_HPKE_CTX_setup_recipient(ctx, key, boringSSLKdf, boringSSLAead, enc, info) != -1) {
+                throw new IllegalStateException("Unable to init EVP_HPKE_CTX");
+            }
+
+            BoringSSLHPKERecipientContext hpkeCtx = new BoringSSLHPKERecipientContext(ctx);
+            ctx = -1;
+            return hpkeCtx;
+        } finally {
+            BoringSSL.EVP_HPKE_KEY_cleanup_and_free(key);
+            if (ctx != -1) {
+                BoringSSL.EVP_HPKE_CTX_cleanup_and_free(ctx);
+            }
+        }
+    }
+
+    @Override
+    public AsymmetricCipherKeyPair deserializePrivateKey(KEM kem, byte[] privateKeyBytes, byte[] publicKeyBytes) {
+        // Validate that KEM is supported by BoringSSL
+        long boringSSLKem = boringSSLKEM(kem);
+
+        long key = -1;
+        try {
+            key = BoringSSL.EVP_HPKE_KEY_new_and_init_or_throw(boringSSLKem, privateKeyBytes);
+            byte[] extractedPublicKey = BoringSSL.EVP_HPKE_KEY_public_key(key);
+            if (!Arrays.equals(publicKeyBytes, extractedPublicKey)) {
+                throw new IllegalArgumentException(
+                        "publicKeyBytes does not contain a valid public key: " + Arrays.toString(publicKeyBytes));
+            }
+            // No need to clone extractedPublicKey as it was returned by our native call.
+            return new BoringSSLAsymmetricCipherKeyPair(privateKeyBytes.clone(), extractedPublicKey);
+        } finally {
+            BoringSSL.EVP_HPKE_KEY_cleanup_and_free(key);
+        }
+    }
+
+    @Override
+    public AsymmetricKeyParameter deserializePublicKey(KEM kem, byte[] publicKeyBytes) {
+        // Validate that KEM is supported by BoringSSL.
+        long boringSSLKem = boringSSLKEM(kem);
+        // The best we can do is to check if the length is correct.
+        if (BoringSSL.EVP_HPKE_KEM_public_key_len(boringSSLKem) != publicKeyBytes.length) {
+            throw new IllegalArgumentException(
+                    "publicKeyBytes does not contain a valid public key: " + Arrays.toString(publicKeyBytes));
+        }
+        return new BoringSSLAsymmetricKeyParameter(publicKeyBytes.clone(), false);
+    }
+
+    @Override
+    public List<AEAD> supportedAEAD() {
+        return SUPPORTED_AEAD_LIST;
+    }
+
+    @Override
+    public List<KEM> supportedKEM() {
+        return SUPPORTED_KEM_LIST;
+    }
+
+    @Override
+    public List<KDF> supportedKDF() {
+        return SUPPORTED_KDF_LIST;
+    }
+
+    @Override
+    public List<Mode> supportedMode() {
+        return SUPPORTED_MODE_LIST;
+    }
+}

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLOHttpCryptoProvider.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLOHttpCryptoProvider.java
@@ -39,6 +39,9 @@ public final class BoringSSLOHttpCryptoProvider implements OHttpCryptoProvider {
     private static final List<KEM> SUPPORTED_KEM_LIST = Collections.singletonList(KEM.X25519_SHA256);
     private static final List<KDF> SUPPORTED_KDF_LIST = Collections.singletonList(KDF.HKDF_SHA256);
 
+    /**
+     * {@link BoringSSLOHttpCryptoProvider} instance.
+     */
     public static final BoringSSLOHttpCryptoProvider INSTANCE = new BoringSSLOHttpCryptoProvider();
 
     private BoringSSLOHttpCryptoProvider() { }
@@ -125,7 +128,7 @@ public final class BoringSSLOHttpCryptoProvider implements OHttpCryptoProvider {
                         encodedAsymmetricKeyParameter(kpE.privateParameters()));
             }
             if (encapsulation == null) {
-                throw new IllegalStateException("Unable to init EVP_HPKE_CTX");
+                throw new IllegalStateException("Unable to setup EVP_HPKE_CTX");
             }
             BoringSSLHPKESenderContext hpkeCtx =
                     new BoringSSLHPKESenderContext(ctx, encapsulation);
@@ -162,7 +165,7 @@ public final class BoringSSLOHttpCryptoProvider implements OHttpCryptoProvider {
             key = BoringSSL.EVP_HPKE_KEY_new_and_init_or_throw(boringSSLKem, privateKeyBytes);
             ctx = BoringSSL.EVP_HPKE_CTX_new_or_throw();
             if (BoringSSL.EVP_HPKE_CTX_setup_recipient(ctx, key, boringSSLKdf, boringSSLAead, enc, info) != -1) {
-                throw new IllegalStateException("Unable to init EVP_HPKE_CTX");
+                throw new IllegalStateException("Unable to setup EVP_HPKE_CTX");
             }
 
             BoringSSLHPKERecipientContext hpkeCtx = new BoringSSLHPKERecipientContext(ctx);

--- a/codec-ohttp-hpke-native-boringssl/pom.xml
+++ b/codec-ohttp-hpke-native-boringssl/pom.xml
@@ -23,8 +23,7 @@
         <artifactId>netty-incubator-codec-parent-ohttp</artifactId>
         <version>0.0.3.Final-SNAPSHOT</version>
     </parent>
-
-    <artifactId>netty-incubator-ohttp-hpke-native-boringssl</artifactId>
+    <artifactId>netty-incubator-codec-ohttp-hpke-native-boringssl</artifactId>
     <version>0.0.3.Final-SNAPSHOT</version>
     <name>Netty/Incubator/Codec/OHTTP/HPKE/Native/BoringSSL</name>
 

--- a/codec-ohttp-hpke-native-boringssl/pom.xml
+++ b/codec-ohttp-hpke-native-boringssl/pom.xml
@@ -41,7 +41,7 @@
         <skipTests>false</skipTests>
         <packaging.type>jar</packaging.type>
         <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
-        <jniLibName>netty_quiche_${os.detected.name}_${os.detected.arch}</jniLibName>
+        <jniLibName>netty_incubator_codec_ohttp_hpke_boringssl_${os.detected.name}_${os.detected.arch}</jniLibName>
         <jniUtilIncludeDir>${project.build.directory}/netty-jni-util/</jniUtilIncludeDir>
         <boringsslSourceDir>${project.build.directory}/boringssl-source</boringsslSourceDir>
         <boringsslBuildDir>${boringsslSourceDir}/build-target</boringsslBuildDir>
@@ -63,10 +63,6 @@
         <extraLdflags />
         <extraConfigureArg />
         <extraConfigureArg2 />
-        <!-- We need 10.12 as minimum to compile quiche and use it.
-             Anything below will fail when trying to load quiche with:
-             Symbol not found: ___isPlatformVersionAtLeast
-        -->
         <macosxDeploymentTarget />
         <bundleNativeCode />
         <crossCompile />
@@ -81,10 +77,6 @@
                 </os>
             </activation>
             <properties>
-                <!--  We need 10.12 as minimum to compile quiche and use it.
-                      Anything below will fail when trying to load quiche with:
-                      Symbol not found: ___isPlatformVersionAtLeast
-                -->
                 <macosxDeploymentTarget>10.12</macosxDeploymentTarget>
                 <!-- On *nix, add ASM flags to disable executable stack -->
                 <cmakeAsmFlags>-Wa,--noexecstack -mmacosx-version-min=${macosxDeploymentTarget}</cmakeAsmFlags>
@@ -102,7 +94,7 @@
         <profile>
             <id>mac-m1-cross-compile</id>
             <properties>
-                <jniLibName>netty_quiche_osx_aarch_64</jniLibName>
+                <jniLibName>netty_incubator_codec_ohttp_hpke_boringssl_osx_aarch_64</jniLibName>
                 <jni.classifier>osx-aarch_64</jni.classifier>
                 <javaModuleNameClassifier>osx.aarch_64</javaModuleNameClassifier>
                 <macosxDeploymentTarget>11.0</macosxDeploymentTarget>
@@ -128,7 +120,7 @@
         <profile>
             <id>mac-intel-cross-compile</id>
             <properties>
-                <jniLibName>netty_quiche_osx_x86_64</jniLibName>
+                <jniLibName>netty_incubator_codec_ohttp_hpke_boringssl_osx_x86_64</jniLibName>
                 <jni.classifier>osx-x86_64</jni.classifier>
                 <javaModuleNameClassifier>osx.x86_64</javaModuleNameClassifier>
                 <macosxDeploymentTarget>10.12</macosxDeploymentTarget>
@@ -186,7 +178,7 @@
                 <libcrypto>libcrypto.a</libcrypto>
                 <extraLdflags>-Wl,--strip-debug -Wl,--exclude-libs,ALL</extraLdflags>
                 <bundleNativeCode>META-INF/native/lib${jniLibName}.so;osname=linux;processor=aarch64</bundleNativeCode>
-                <jniLibName>netty_quiche_linux_aarch_64</jniLibName>
+                <jniLibName>netty_incubator_codec_ohttp_hpke_boringssl_linux_aarch_64</jniLibName>
                 <jni.classifier>linux-aarch_64</jni.classifier>
                 <javaModuleNameClassifier>linux.aarch_64</javaModuleNameClassifier>
                 <extraConfigureArg>--host=aarch64-linux-gnu</extraConfigureArg>
@@ -598,6 +590,27 @@
             <version>${netty.jni-util.version}</version>
             <classifier>sources</classifier>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>netty-incubator-codec-ohttp-hpke-classes-boringssl</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/codec-ohttp-hpke-native-boringssl/pom.xml
+++ b/codec-ohttp-hpke-native-boringssl/pom.xml
@@ -1,0 +1,603 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2023 The Netty Project
+  ~
+  ~ The Netty Project licenses this file to you under the Apache License,
+  ~ version 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at:
+  ~
+  ~   https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.netty.incubator</groupId>
+        <artifactId>netty-incubator-codec-parent-ohttp</artifactId>
+        <version>0.0.3.Final-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>netty-incubator-ohttp-hpke-native-boringssl</artifactId>
+    <version>0.0.3.Final-SNAPSHOT</version>
+    <name>Netty/Incubator/Codec/OHTTP/HPKE/Native/BoringSSL</name>
+
+    <packaging>${packaging.type}</packaging>
+
+    <properties>
+        <javaModuleNameClassifier>${os.detected.name}.${os.detected.arch}</javaModuleNameClassifier>
+        <javaModuleNameWithClassifier>${javaModuleName}.${javaModuleNameClassifier}</javaModuleNameWithClassifier>
+        <javaModuleName>io.netty.incubator.codec.hpke.boringssl</javaModuleName>
+
+        <fragmentHost>io.netty.incubator.netty-incubator-codec-ohttp-hpke-classes-native</fragmentHost>
+        <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
+        <nativeLibOnlyDir>${project.build.directory}/native-lib-only</nativeLibOnlyDir>
+        <skipTests>false</skipTests>
+        <packaging.type>jar</packaging.type>
+        <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
+        <jniLibName>netty_quiche_${os.detected.name}_${os.detected.arch}</jniLibName>
+        <jniUtilIncludeDir>${project.build.directory}/netty-jni-util/</jniUtilIncludeDir>
+        <boringsslSourceDir>${project.build.directory}/boringssl-source</boringsslSourceDir>
+        <boringsslBuildDir>${boringsslSourceDir}/build-target</boringsslBuildDir>
+        <boringsslHomeDir>${project.build.directory}/boringssl</boringsslHomeDir>
+        <boringsslHomeBuildDir>${boringsslHomeDir}/build</boringsslHomeBuildDir>
+        <boringsslHomeIncludeDir>${boringsslHomeDir}/include</boringsslHomeIncludeDir>
+        <boringsslRepository>https://boringssl.googlesource.com/boringssl</boringsslRepository>
+        <!-- Lets use what we use in netty-tcnative-boringssl-static -->
+        <boringsslBranch>chromium-stable</boringsslBranch>
+        <boringsslCommitSha>dd5219451c3ce26221762a15d867edf43b463bb2</boringsslCommitSha>
+
+        <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
+        <templateDir>${project.build.directory}/template</templateDir>
+        <cflags />
+        <ldflags />
+        <extraCmakeFlags />
+        <extraCflags />
+        <extraCxxflags />
+        <extraLdflags />
+        <extraConfigureArg />
+        <extraConfigureArg2 />
+        <!-- We need 10.12 as minimum to compile quiche and use it.
+             Anything below will fail when trying to load quiche with:
+             Symbol not found: ___isPlatformVersionAtLeast
+        -->
+        <macosxDeploymentTarget />
+        <bundleNativeCode />
+        <crossCompile />
+    </properties>
+
+    <profiles>
+        <profile>
+            <id>mac</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                </os>
+            </activation>
+            <properties>
+                <!--  We need 10.12 as minimum to compile quiche and use it.
+                      Anything below will fail when trying to load quiche with:
+                      Symbol not found: ___isPlatformVersionAtLeast
+                -->
+                <macosxDeploymentTarget>10.12</macosxDeploymentTarget>
+                <!-- On *nix, add ASM flags to disable executable stack -->
+                <cmakeAsmFlags>-Wa,--noexecstack -mmacosx-version-min=${macosxDeploymentTarget}</cmakeAsmFlags>
+                <extraCflags>-mmacosx-version-min=${macosxDeploymentTarget}</extraCflags>
+                <cmakeCFlags>${extraCflags} -O3 -fno-omit-frame-pointer</cmakeCFlags>
+                <!-- We need to define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when building boringssl on centos 6 -->
+                <cmakeCxxFlags>${extraCxxflags} -O3 -fno-omit-frame-pointer -Wno-error=range-loop-analysis</cmakeCxxFlags>
+                <libssl>libssl.a</libssl>
+                <libcrypto>libcrypto.a</libcrypto>
+                <extraLdflags>-platform_version,macos,${macosxDeploymentTarget},${macosxDeploymentTarget} -mmacosx-version-min=${macosxDeploymentTarget}</extraLdflags>
+                <extraConfigureArg>MACOSX_DEPLOYMENT_TARGET=${macosxDeploymentTarget}</extraConfigureArg>
+                <bundleNativeCode>META-INF/native/lib${jniLibName}.jnilib;osname=macos;osname=macosx;processor=${os.detected.arch}</bundleNativeCode>
+            </properties>
+        </profile>
+        <profile>
+            <id>mac-m1-cross-compile</id>
+            <properties>
+                <jniLibName>netty_quiche_osx_aarch_64</jniLibName>
+                <jni.classifier>osx-aarch_64</jni.classifier>
+                <javaModuleNameClassifier>osx.aarch_64</javaModuleNameClassifier>
+                <macosxDeploymentTarget>11.0</macosxDeploymentTarget>
+                <extraCflags>-target arm64-apple-macos11</extraCflags>
+                <extraCxxflags>-target arm64-apple-macos11</extraCxxflags>
+                <!-- On *nix, add ASM flags to disable executable stack -->
+                <cmakeAsmFlags>-Wa,--noexecstack -target arm64-apple-macos11</cmakeAsmFlags>
+                <extraCmakeFlags>-DCMAKE_SYSTEM_PROCESSOR=arm64 -DCMAKE_OSX_ARCHITECTURES=arm64</extraCmakeFlags>
+                <cmakeCFlags>${extraCflags} -O3 -fno-omit-frame-pointer</cmakeCFlags>
+                <!-- We need to define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when building boringssl on centos 6 -->
+                <cmakeCxxFlags>${extraCxxflags} -O3 -fno-omit-frame-pointer -Wno-error=range-loop-analysis</cmakeCxxFlags>
+                <libssl>libssl.a</libssl>
+                <libcrypto>libcrypto.a</libcrypto>
+                <extraLdflags>-arch arm64 -platform_version,macos,${macosxDeploymentTarget},${macosxDeploymentTarget}</extraLdflags>
+                <extraConfigureArg>--host=aarch64-apple-darwin</extraConfigureArg>
+                <extraConfigureArg2>MACOSX_DEPLOYMENT_TARGET=${macosxDeploymentTarget}</extraConfigureArg2>
+                <bundleNativeCode>META-INF/native/lib${jniLibName}.jnilib;osname=macos;osname=macosx;processor=aarch64</bundleNativeCode>
+                <!-- Don't run tests as we can't load the aarch64 lib on a x86_64 system -->
+                <skipTests>true</skipTests>
+                <crossCompile>mac</crossCompile>
+            </properties>
+        </profile>
+        <profile>
+            <id>mac-intel-cross-compile</id>
+            <properties>
+                <jniLibName>netty_quiche_osx_x86_64</jniLibName>
+                <jni.classifier>osx-x86_64</jni.classifier>
+                <javaModuleNameClassifier>osx.x86_64</javaModuleNameClassifier>
+                <macosxDeploymentTarget>10.12</macosxDeploymentTarget>
+                <extraCflags>-target x86_64-apple-macos10.12 -mmacosx-version-min=${macosxDeploymentTarget}</extraCflags>
+                <extraCxxflags>-target x86_64-apple-macos10.12</extraCxxflags>
+                <!-- On *nix, add ASM flags to disable executable stack -->
+                <cmakeAsmFlags>-Wa,--noexecstack -target x86_64-apple-macos10.12 -mmacosx-version-min=${macosxDeploymentTarget}</cmakeAsmFlags>
+                <extraCmakeFlags>-DCMAKE_SYSTEM_PROCESSOR=x86_64 -DCMAKE_OSX_ARCHITECTURES=x86_64</extraCmakeFlags>
+                <cmakeCFlags>${extraCflags} -O3 -fno-omit-frame-pointer</cmakeCFlags>
+                <!-- We need to define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when building boringssl on centos 6 -->
+                <cmakeCxxFlags>${extraCxxflags} -O3 -fno-omit-frame-pointer -Wno-error=range-loop-analysis</cmakeCxxFlags>
+                <libssl>libssl.a</libssl>
+                <libcrypto>libcrypto.a</libcrypto>
+                <extraLdflags>-arch x86_64 -platform_version,macos,${macosxDeploymentTarget},${macosxDeploymentTarget} -mmacosx-version-min=${macosxDeploymentTarget}</extraLdflags>
+                <extraConfigureArg>--host=x86_64-apple-darwin</extraConfigureArg>
+                <extraConfigureArg2>MACOSX_DEPLOYMENT_TARGET=${macosxDeploymentTarget}</extraConfigureArg2>
+                <bundleNativeCode>META-INF/native/lib${jniLibName}.jnilib;osname=macos;osname=macosx;processor=x86_64</bundleNativeCode>
+                <!-- Don't run tests as we can't load the x86_64 lib on a aarch64 system -->
+                <skipTests>true</skipTests>
+                <crossCompile>mac</crossCompile>
+            </properties>
+        </profile>
+        <profile>
+            <id>linux</id>
+            <activation>
+                <os>
+                    <family>linux</family>
+                </os>
+            </activation>
+            <properties>
+                <extraCflags>-O3 -fno-omit-frame-pointer</extraCflags>
+                <extraCxxflags>-O3 -fno-omit-frame-pointer</extraCxxflags>
+                <!-- On *nix, add ASM flags to disable executable stack -->
+                <cmakeAsmFlags>-Wa,--noexecstack</cmakeAsmFlags>
+                <cmakeCFlags>${extraCflags}</cmakeCFlags>
+                <!-- We need to define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when building boringssl on centos 6 -->
+                <cmakeCxxFlags>${extraCxxflags} -Wno-error=maybe-uninitialized -Wno-error=shadow -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS</cmakeCxxFlags>
+                <libssl>libssl.a</libssl>
+                <libcrypto>libcrypto.a</libcrypto>
+                <extraLdflags>-Wl,--strip-debug -Wl,--exclude-libs,ALL -Wl,-lrt</extraLdflags>
+                <bundleNativeCode>META-INF/native/lib${jniLibName}.so;osname=linux;processor=${os.detected.arch}</bundleNativeCode>
+            </properties>
+        </profile>
+        <profile>
+            <id>linux-aarch64</id>
+            <properties>
+                <extraCflags>-O3 -fno-omit-frame-pointer</extraCflags>
+                <extraCxxflags>-O3 -fno-omit-frame-pointer</extraCxxflags>
+                <!-- On *nix, add ASM flags to disable executable stack -->
+                <cmakeAsmFlags>-Wa,--noexecstack</cmakeAsmFlags>
+                <cmakeCFlags>${extraCflags}</cmakeCFlags>
+                <!-- We need to define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when building boringssl on centos 6 -->
+                <cmakeCxxFlags>${extraCxxflags} -Wno-error=maybe-uninitialized -Wno-error=shadow -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS</cmakeCxxFlags>
+                <libssl>libssl.a</libssl>
+                <libcrypto>libcrypto.a</libcrypto>
+                <extraLdflags>-Wl,--strip-debug -Wl,--exclude-libs,ALL</extraLdflags>
+                <bundleNativeCode>META-INF/native/lib${jniLibName}.so;osname=linux;processor=aarch64</bundleNativeCode>
+                <jniLibName>netty_quiche_linux_aarch_64</jniLibName>
+                <jni.classifier>linux-aarch_64</jni.classifier>
+                <javaModuleNameClassifier>linux.aarch_64</javaModuleNameClassifier>
+                <extraConfigureArg>--host=aarch64-linux-gnu</extraConfigureArg>
+                <extraConfigureArg2>CC=aarch64-none-linux-gnu-gcc</extraConfigureArg2>
+                <extraCmakeFlags>-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-none-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-none-linux-gnu-g++</extraCmakeFlags>
+                <!-- Don't run tests as we can't load the aarch64 lib on a x86_64 system -->
+                <skipTests>true</skipTests>
+                <crossCompile>linux</crossCompile>
+            </properties>
+        </profile>
+    </profiles>
+
+    <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.0</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <!-- Also include c files in source jar -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${nativeSourceDirectory}</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <!-- unpack netty-jni-util files -->
+                    <execution>
+                        <id>unpack</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeGroupIds>io.netty</includeGroupIds>
+                            <includeArtifactIds>netty-jni-util</includeArtifactIds>
+                            <classifier>sources</classifier>
+                            <outputDirectory>${jniUtilIncludeDir}</outputDirectory>
+                            <includes>**.h,**.c</includes>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+
+                    <!-- Build the BoringSSL static libs -->
+                    <execution>
+                        <id>build-boringssl</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <!-- Add the ant tasks from ant-contrib -->
+                                <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+                                <property environment="env" />
+                                <if>
+                                    <available file="${boringsslHomeDir}" />
+                                    <then>
+                                        <echo message="BoringSSL was already build, skipping the build step." />
+                                    </then>
+                                    <else>
+                                        <if>
+                                            <available file="${boringsslSourceDir}" />
+                                            <then>
+                                                <echo message="BoringSSL was already cloned, skipping the clone step." />
+                                            </then>
+                                            <else>
+                                                <echo message="Clone BoringSSL" />
+
+                                                <exec executable="git" failonerror="true" dir="${project.build.directory}" resolveexecutable="true">
+                                                    <arg value="clone" />
+                                                    <arg value="--branch" />
+                                                    <arg value="${boringsslBranch}" />
+                                                    <arg value="${boringsslRepository}" />
+                                                    <arg value="${boringsslSourceDir}" />
+                                                </exec>
+                                            </else>
+                                        </if>
+
+                                        <echo message="Building BoringSSL" />
+
+                                        <!-- Use the known SHA of the commit -->
+                                        <exec executable="git" failonerror="true" dir="${boringsslSourceDir}" resolveexecutable="true">
+                                            <arg value="checkout" />
+                                            <arg value="${boringsslCommitSha}" />
+                                        </exec>
+
+                                        <mkdir dir="${boringsslBuildDir}" />
+
+                                        <exec executable="cmake" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
+                                            <env key="MACOSX_DEPLOYMENT_TARGET" value="${macosxDeploymentTarget}" />
+                                            <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
+                                            <arg value="-DCMAKE_BUILD_TYPE=Release" />
+                                            <arg value="-DCMAKE_ASM_FLAGS=${cmakeAsmFlags}" />
+                                            <arg value="-DCMAKE_C_FLAGS_RELEASE=${cmakeCFlags}" />
+                                            <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
+                                            <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
+                                            <arg line="${extraCmakeFlags}" />
+                                            <arg value="-GNinja" />
+                                            <arg value="${boringsslSourceDir}" />
+                                        </exec>
+                                        <if>
+                                            <!-- may be called ninja-build or ninja -->
+                                            <!-- See https://github.com/netty/netty-tcnative/issues/475 -->
+                                            <available file="ninja-build" filepath="${PATH}" />
+                                            <then>
+                                                <property name="ninjaExecutable" value="ninja-build" />
+                                            </then>
+                                            <else>
+                                                <property name="ninjaExecutable" value="ninja" />
+                                            </else>
+                                        </if>
+                                        <exec executable="${ninjaExecutable}" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
+                                            <arg value="crypto" />
+                                            <arg value="ssl" />
+                                        </exec>
+
+                                        <!-- Only copy the libs and header files we need -->
+                                        <mkdir dir="${boringsslHomeBuildDir}" />
+                                        <copy file="${boringsslBuildDir}/ssl/${libssl}" todir="${boringsslHomeBuildDir}" verbose="true" />
+                                        <copy file="${boringsslBuildDir}/crypto/${libcrypto}" todir="${boringsslHomeBuildDir}" verbose="true" />
+                                        <copy todir="${boringsslHomeIncludeDir}" verbose="true">
+                                            <fileset dir="${boringsslSourceDir}/include" />
+                                        </copy>
+                                    </else>
+                                </if>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-src</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <!-- Copy all of the c code -->
+                                <delete dir="${generatedSourcesDir}" quiet="true" />
+                                <copy todir="${generatedSourcesDir}/c">
+                                    <fileset dir="${project.basedir}/src/main/c" />
+                                </copy>
+
+                                <copy todir="${generatedSourcesDir}/c">
+                                    <fileset dir="${jniUtilIncludeDir}" />
+                                </copy>
+                            </target>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <!-- Adjust our template and copy it over so it can be used when compiling on windows -->
+                        <id>setup-template</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <!-- Add the ant tasks from ant-contrib -->
+                                <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+                                <property environment="env" />
+                                <!-- Convert the paths to windows format -->
+                                <pathconvert property="boringsslHomeIncludeWindowsDir" targetos="windows">
+                                    <path location="${boringsslHomeIncludeDir}" />
+                                </pathconvert>
+                                <pathconvert property="boringsslHomeBuildWindowsDir" targetos="windows">
+                                    <path location="${boringsslHomeBuildDir}" />
+                                </pathconvert>
+                                <!-- Copy custom.m4 to fix building library without version-suffix on Android -->
+                                <if>
+                                    <equals arg1="${os.detected.name}" arg2="windows" />
+                                    <then>
+                                        <!-- Copy and filter the template MSVC project -->
+                                        <filter token="BORINGSSL_INCLUDE_DIR" value="${boringsslHomeIncludeWindowsDir}" />
+                                        <filter token="BORINGSSL_LIB_DIR" value="${boringsslHomeBuildWindowsDir}" />
+                                        <filter token="CRYPTO_LIB" value="${libcrypto}" />
+                                        <filter token="SSL_LIB" value="${libssl}" />
+                                        <copy file="src/main/native-package/vs2010.custom.props.template" tofile="${templateDir}/vs2010.custom.props" filtering="true" overwrite="true" verbose="true" />
+                                    </then>
+                                    <else>
+                                        <!-- Copy and filter custom.m4 -->
+                                        <filter token="BORINGSSL_INCLUDE_DIR" value="${boringsslHomeIncludeDir}" />
+                                        <filter token="BORINGSSL_LIB_DIR" value="${boringsslHomeBuildDir}" />
+                                        <filter token="CRYPTO_LIB" value="crypto" />
+                                        <filter token="SSL_LIB" value="ssl" />
+                                        <filter token="EXTRA_LDFLAGS" value="${extraLdflags}" />
+                                        <filter token="EXTRA_CFLAGS" value="${extraCflags}" />
+                                        <copy file="src/main/native-package/m4/custom.m4.template" tofile="${templateDir}/m4/custom.m4" filtering="true" overwrite="true" verbose="true" />
+                                    </else>
+                                </if>
+                            </target>
+                        </configuration>
+                    </execution>
+
+                    <!-- Copy the native lib that was generated and the license material for attribution -->
+                    <execution>
+                        <id>copy-native-lib-and-license</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <!-- Add the ant tasks from ant-contrib -->
+                                <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+
+                                <copy todir="${project.build.outputDirectory}" includeEmptyDirs="false">
+                                    <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
+                                    <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="META-INF/native/\1" />
+                                </copy>
+
+                                <!-- Copy license material for attribution-->
+                                <copy file="../NOTICE.txt" todir="${project.build.outputDirectory}/META-INF/" />
+                                <copy file="../LICENSE.txt" todir="${project.build.outputDirectory}/META-INF/" />
+                                <copy todir="${project.build.outputDirectory}/META-INF/license">
+                                    <fileset dir="../license" />
+                                </copy>
+
+                            </target>
+                        </configuration>
+                    </execution>
+                    <!-- Copy the manifest file that we populated so far so we can use it as a starting point when generating the jars and adding more things to it. -->
+                    <execution>
+                        <id>copy-manifest</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <copy file="${project.build.outputDirectory}/META-INF/MANIFEST.MF" tofile="${project.build.directory}/manifests/MANIFEST-native.MF" />
+                                <copy file="${project.build.outputDirectory}/META-INF/MANIFEST.MF" tofile="${project.build.directory}/manifests/MANIFEST.MF" />
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- always produce osgi bundles -->
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                        <configuration>
+                            <supportedProjectTypes>
+                                <supportedProjectType>jar</supportedProjectType>
+                                <supportedProjectType>bundle</supportedProjectType>
+                            </supportedProjectTypes>
+                            <instructions>
+                                <Export-Package>${project.groupId}.*</Export-Package>
+                                <BoringSSL-Revision>${boringsslCommitSha}</BoringSSL-Revision>
+                                <BoringSSL-Branch>${boringsslBranch}</BoringSSL-Branch>
+                            </instructions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <!-- Eclipse-related OSGi manifests
+                      See https://github.com/netty/netty/issues/3886
+                      More information: https://rajakannappan.blogspot.ie/2010/03/automating-eclipse-source-bundle.html -->
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Bundle-ManifestVersion>2</Bundle-ManifestVersion>
+                            <Bundle-Name>${project.name}</Bundle-Name>
+                            <Bundle-SymbolicName>${project.groupId}.${project.artifactId}.source</Bundle-SymbolicName>
+                            <Bundle-Vendor>${project.organization.name}</Bundle-Vendor>
+                            <Bundle-Version>${parsedVersion.osgiVersion}</Bundle-Version>
+                            <Eclipse-SourceBundle>${project.groupId}.${project.artifactId};version="${parsedVersion.osgiVersion}";roots:="."</Eclipse-SourceBundle>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>attach-test-sources</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>test-jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.fusesource.hawtjni</groupId>
+                <artifactId>hawtjni-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-native-lib</id>
+                        <configuration>
+                            <name>${jniLibName}</name>
+                            <nativeSourceDirectory>${generatedSourcesDir}</nativeSourceDirectory>
+                            <customPackageDirectory>${templateDir}</customPackageDirectory>
+                            <windowsBuildTool>msbuild</windowsBuildTool>
+                            <windowsCustomProps>true</windowsCustomProps>
+                            <windowsPlatformToolset>v142</windowsPlatformToolset>
+                            <libDirectory>${nativeLibOnlyDir}</libDirectory>
+                            <verbose>true</verbose>
+                            <configureArgs>
+                                <configureArg>${extraConfigureArg}</configureArg>
+                                <configureArg>${extraConfigureArg2}</configureArg>
+                                <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
+                            </configureArgs>
+                        </configuration>
+                        <goals>
+                            <goal>generate</goal>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <!-- Exclude native lib and attribution for the jar without classifier-->
+                            <excludes>
+                                <exclude>META-INF/native/**</exclude>
+                                <exclude>META-INF/license/**</exclude>
+                                <exclude>META-INF/NOTICE.txt</exclude>
+                                <exclude>META-INF/LICENSE.txt</exclude>
+                            </excludes>
+                            <archive>
+                                <manifest>
+                                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                </manifest>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
+                                </manifestEntries>
+                                <index>true</index>
+                                <manifestFile>${project.build.directory}/manifests/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                    <!-- Generate the JAR that contains the native library in it. -->
+                    <execution>
+                        <id>native-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                </manifest>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>${javaModuleNameWithClassifier}</Automatic-Module-Name>
+                                    <Fragment-Host>${fragmentHost}</Fragment-Host>
+                                    <Bundle-NativeCode>${bundleNativeCode}</Bundle-NativeCode>
+                                </manifestEntries>
+                                <index>true</index>
+                                <manifestFile>${project.build.directory}/manifests/MANIFEST-native.MF</manifestFile>
+                            </archive>
+                            <classifier>${jni.classifier}</classifier>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-jni-util</artifactId>
+            <version>${netty.jni-util.version}</version>
+            <classifier>sources</classifier>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+</project>

--- a/codec-ohttp-hpke-native-boringssl/pom.xml
+++ b/codec-ohttp-hpke-native-boringssl/pom.xml
@@ -84,7 +84,6 @@
                 <cmakeCFlags>${extraCflags} -O3 -fno-omit-frame-pointer</cmakeCFlags>
                 <!-- We need to define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when building boringssl on centos 6 -->
                 <cmakeCxxFlags>${extraCxxflags} -O3 -fno-omit-frame-pointer -Wno-error=range-loop-analysis</cmakeCxxFlags>
-                <libssl>libssl.a</libssl>
                 <libcrypto>libcrypto.a</libcrypto>
                 <extraLdflags>-platform_version,macos,${macosxDeploymentTarget},${macosxDeploymentTarget} -mmacosx-version-min=${macosxDeploymentTarget}</extraLdflags>
                 <extraConfigureArg>MACOSX_DEPLOYMENT_TARGET=${macosxDeploymentTarget}</extraConfigureArg>
@@ -106,7 +105,6 @@
                 <cmakeCFlags>${extraCflags} -O3 -fno-omit-frame-pointer</cmakeCFlags>
                 <!-- We need to define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when building boringssl on centos 6 -->
                 <cmakeCxxFlags>${extraCxxflags} -O3 -fno-omit-frame-pointer -Wno-error=range-loop-analysis</cmakeCxxFlags>
-                <libssl>libssl.a</libssl>
                 <libcrypto>libcrypto.a</libcrypto>
                 <extraLdflags>-arch arm64 -platform_version,macos,${macosxDeploymentTarget},${macosxDeploymentTarget}</extraLdflags>
                 <extraConfigureArg>--host=aarch64-apple-darwin</extraConfigureArg>
@@ -132,7 +130,6 @@
                 <cmakeCFlags>${extraCflags} -O3 -fno-omit-frame-pointer</cmakeCFlags>
                 <!-- We need to define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when building boringssl on centos 6 -->
                 <cmakeCxxFlags>${extraCxxflags} -O3 -fno-omit-frame-pointer -Wno-error=range-loop-analysis</cmakeCxxFlags>
-                <libssl>libssl.a</libssl>
                 <libcrypto>libcrypto.a</libcrypto>
                 <extraLdflags>-arch x86_64 -platform_version,macos,${macosxDeploymentTarget},${macosxDeploymentTarget} -mmacosx-version-min=${macosxDeploymentTarget}</extraLdflags>
                 <extraConfigureArg>--host=x86_64-apple-darwin</extraConfigureArg>
@@ -158,7 +155,6 @@
                 <cmakeCFlags>${extraCflags}</cmakeCFlags>
                 <!-- We need to define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when building boringssl on centos 6 -->
                 <cmakeCxxFlags>${extraCxxflags} -Wno-error=maybe-uninitialized -Wno-error=shadow -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS</cmakeCxxFlags>
-                <libssl>libssl.a</libssl>
                 <libcrypto>libcrypto.a</libcrypto>
                 <extraLdflags>-Wl,--strip-debug -Wl,--exclude-libs,ALL -Wl,-lrt</extraLdflags>
                 <bundleNativeCode>META-INF/native/lib${jniLibName}.so;osname=linux;processor=${os.detected.arch}</bundleNativeCode>
@@ -174,7 +170,6 @@
                 <cmakeCFlags>${extraCflags}</cmakeCFlags>
                 <!-- We need to define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when building boringssl on centos 6 -->
                 <cmakeCxxFlags>${extraCxxflags} -Wno-error=maybe-uninitialized -Wno-error=shadow -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS</cmakeCxxFlags>
-                <libssl>libssl.a</libssl>
                 <libcrypto>libcrypto.a</libcrypto>
                 <extraLdflags>-Wl,--strip-debug -Wl,--exclude-libs,ALL</extraLdflags>
                 <bundleNativeCode>META-INF/native/lib${jniLibName}.so;osname=linux;processor=aarch64</bundleNativeCode>
@@ -321,7 +316,6 @@
 
                                         <!-- Only copy the libs and header files we need -->
                                         <mkdir dir="${boringsslHomeBuildDir}" />
-                                        <copy file="${boringsslBuildDir}/ssl/${libssl}" todir="${boringsslHomeBuildDir}" verbose="true" />
                                         <copy file="${boringsslBuildDir}/crypto/${libcrypto}" todir="${boringsslHomeBuildDir}" verbose="true" />
                                         <copy todir="${boringsslHomeIncludeDir}" verbose="true">
                                             <fileset dir="${boringsslSourceDir}/include" />
@@ -379,7 +373,6 @@
                                         <filter token="BORINGSSL_INCLUDE_DIR" value="${boringsslHomeIncludeWindowsDir}" />
                                         <filter token="BORINGSSL_LIB_DIR" value="${boringsslHomeBuildWindowsDir}" />
                                         <filter token="CRYPTO_LIB" value="${libcrypto}" />
-                                        <filter token="SSL_LIB" value="${libssl}" />
                                         <copy file="src/main/native-package/vs2010.custom.props.template" tofile="${templateDir}/vs2010.custom.props" filtering="true" overwrite="true" verbose="true" />
                                     </then>
                                     <else>
@@ -387,7 +380,6 @@
                                         <filter token="BORINGSSL_INCLUDE_DIR" value="${boringsslHomeIncludeDir}" />
                                         <filter token="BORINGSSL_LIB_DIR" value="${boringsslHomeBuildDir}" />
                                         <filter token="CRYPTO_LIB" value="crypto" />
-                                        <filter token="SSL_LIB" value="ssl" />
                                         <filter token="EXTRA_LDFLAGS" value="${extraLdflags}" />
                                         <filter token="EXTRA_CFLAGS" value="${extraCflags}" />
                                         <copy file="src/main/native-package/m4/custom.m4.template" tofile="${templateDir}/m4/custom.m4" filtering="true" overwrite="true" verbose="true" />

--- a/codec-ohttp-hpke-native-boringssl/src/main/c/netty_incubator_codec_ohttp_hpke_boringssl.c
+++ b/codec-ohttp-hpke-native-boringssl/src/main/c/netty_incubator_codec_ohttp_hpke_boringssl.c
@@ -234,9 +234,7 @@ static jint netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_nonce_length(JNI
 static jint netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_max_overhead(JNIEnv* env, jclass clazz, jlong aead) {
     return (jint) EVP_AEAD_max_overhead((EVP_AEAD *) aead);
 }
-static jint netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_max_tag_len(JNIEnv* env, jclass clazz, jlong aead) {
-    return (jint) EVP_AEAD_max_tag_len((EVP_AEAD *) aead);
-}
+
 
 static jlong netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_CTX_new(JNIEnv* env, jclass clazz, jlong aead, jbyteArray key_array, jint tag_len) {
     size_t key_len = (size_t)(*env)->GetArrayLength(env, key_array);
@@ -308,7 +306,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "EVP_HPKE_CTX_max_overhead", "(J)I", (void * ) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_max_overhead },
   { "EVP_HPKE_KEY_new", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_new },
   { "EVP_HPKE_KEY_free", "(J)V", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_free },
-  { "EVP_HPKE_KEY_init", "(JJJI)I", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_init },
+  { "EVP_HPKE_KEY_init", "(JJ[B)I", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_init },
   { "EVP_HPKE_KEY_public_key", "(J)[B", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_public_key },
   { "EVP_HPKE_KEY_private_key", "(J)[B", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_private_key },
   { "EVP_HPKE_KEM_public_key_len", "(J)I", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEM_public_key_len },
@@ -317,7 +315,6 @@ static const JNINativeMethod fixed_method_table[] = {
   { "EVP_AEAD_key_length", "(J)I", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_key_length },
   { "EVP_AEAD_nonce_length", "(J)I", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_nonce_length },
   { "EVP_AEAD_max_overhead", "(J)I", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_max_overhead },
-  { "EVP_AEAD_max_tag_len", "(J)I", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_max_tag_len },
 
   { "EVP_AEAD_CTX_new", "(J[BI)J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_CTX_new },
   { "EVP_AEAD_CTX_cleanup", "(J)V", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_CTX_cleanup },

--- a/codec-ohttp-hpke-native-boringssl/src/main/c/netty_incubator_codec_ohttp_hpke_boringssl.c
+++ b/codec-ohttp-hpke-native-boringssl/src/main/c/netty_incubator_codec_ohttp_hpke_boringssl.c
@@ -66,6 +66,18 @@ static jlong netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_chacha20_poly13
     return (jlong) EVP_hpke_chacha20_poly1305();
 }
 
+static jlong netty_incubator_codec_ohttp_hpke_boringssl_EVP_aead_aes_128_gcm(JNIEnv* env, jclass clazz) {
+    return (jlong) EVP_aead_aes_128_gcm();
+}
+
+static jlong netty_incubator_codec_ohttp_hpke_boringssl_EVP_aead_aes_256_gcm(JNIEnv* env, jclass clazz) {
+    return (jlong) EVP_aead_aes_256_gcm();
+}
+
+static jlong netty_incubator_codec_ohttp_hpke_boringssl_EVP_aead_chacha20_poly1305(JNIEnv* env, jclass clazz) {
+    return (jlong) EVP_aead_chacha20_poly1305();
+}
+
 static jint netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_DEFAULT_TAG_LENGTH(JNIEnv* env, jclass clazz) {
     return (jint) EVP_AEAD_DEFAULT_TAG_LENGTH;
 }
@@ -137,7 +149,7 @@ static jint netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_setup_recipi
                                                     jbyteArray info_bytes) {
     size_t enc_len = (size_t) (*env)->GetArrayLength(env, enc_bytes);
     const uint8_t *enc = (const uint8_t*) (*env)->GetByteArrayElements(env, enc_bytes, 0);
-    size_t info_len = (size_t) (*env)->GetArrayLength(env, enc_bytes);
+    size_t info_len = (size_t) (*env)->GetArrayLength(env, info_bytes);
     const uint8_t *info = (const uint8_t*) (*env)->GetByteArrayElements(env, info_bytes, 0);
 
     int result = EVP_HPKE_CTX_setup_recipient((EVP_HPKE_CTX *) ctx, (const EVP_HPKE_KEY *) key, (const EVP_HPKE_KDF *)kdf,
@@ -206,6 +218,10 @@ static jlong netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_new(JNIEnv*
     return (jlong) EVP_HPKE_KEY_new();
 }
 
+static void netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_cleanup(JNIEnv* env, jclass clazz, jlong key) {
+    EVP_HPKE_KEY_cleanup((EVP_HPKE_KEY *) key);
+}
+
 static void netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_free(JNIEnv* env, jclass clazz, jlong key) {
     EVP_HPKE_KEY_free((EVP_HPKE_KEY *) key);
 }
@@ -261,8 +277,10 @@ static jlong netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_CTX_new(JNIEnv*
     const uint8_t *key = (const uint8_t*) (*env)->GetByteArrayElements(env, key_array, 0);
 
     EVP_AEAD_CTX* ctx = EVP_AEAD_CTX_new((const EVP_AEAD *) aead, key, key_len, (size_t) tag_len);
-
     (*env)->ReleaseByteArrayElements(env, key_array, (jbyte *) key, JNI_ABORT);
+    if (ctx == NULL) {
+        return -1;
+    }
     return (jlong) ctx;
 }
 
@@ -353,6 +371,10 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "EVP_hpke_aes_128_gcm", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_aes_128_gcm },
   { "EVP_hpke_aes_256_gcm", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_aes_256_gcm },
   { "EVP_hpke_chacha20_poly1305", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_chacha20_poly1305 },
+
+  { "EVP_aead_aes_128_gcm", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_aead_aes_128_gcm },
+  { "EVP_aead_aes_256_gcm", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_aead_aes_256_gcm },
+  { "EVP_aead_chacha20_poly1305", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_aead_chacha20_poly1305 },
   { "EVP_AEAD_DEFAULT_TAG_LENGTH", "()I", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_DEFAULT_TAG_LENGTH }
 };
 
@@ -370,6 +392,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "EVP_HPKE_CTX_kdf", "(J)J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_kdf },
   { "EVP_HPKE_CTX_max_overhead", "(J)I", (void * ) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_max_overhead },
   { "EVP_HPKE_KEY_new", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_new },
+  { "EVP_HPKE_KEY_cleanup", "(J)V", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_cleanup },
   { "EVP_HPKE_KEY_free", "(J)V", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_free },
   { "EVP_HPKE_KEY_init", "(JJ[B)I", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_init },
   { "EVP_HPKE_KEY_public_key", "(J)[B", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_public_key },

--- a/codec-ohttp-hpke-native-boringssl/src/main/c/netty_incubator_codec_ohttp_hpke_boringssl.c
+++ b/codec-ohttp-hpke-native-boringssl/src/main/c/netty_incubator_codec_ohttp_hpke_boringssl.c
@@ -1,0 +1,407 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#include <jni.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+#include "netty_jni_util.h"
+#include "netty_incubator_codec_ohttp_hpke_boringssl.h"
+
+#include <openssl/hpke.h>
+#include <openssl/aead.h>
+
+// Add define if NETTY_QUIC_BUILD_STATIC is defined so it is picked up in netty_jni_util.c
+#ifdef NETTY_OHTTP_HPKE_BORINGSSL_BUILD_STATIC
+#define NETTY_JNI_UTIL_BUILD_STATIC
+#endif
+
+#define STATICALLY_CLASSNAME "io/netty/incubator/codec/hpke/boringssl/BoringSSLNativeStaticallyReferencedJniMethods"
+#define BORINGSSL_CLASSNAME "io/netty/incubator/codec/hpke/boringssl/BoringSSL"
+#define LIBRARYNAME "netty_incubator_codec_ohttp_hpke_boringssl"
+
+static char const* staticPackagePrefix = NULL;
+
+static jbyteArray to_byte_array(JNIEnv* env, int result, const uint8_t* data, size_t out_len) {
+    if (result == 1) {
+        jbyteArray array = (*env)->NewByteArray(env, out_len);
+        (*env)->SetByteArrayRegion (env, array, 0, out_len, (jbyte *) data);
+        return array;
+    }
+    return NULL;
+}
+
+static jlong netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_x25519_hkdf_sha256(JNIEnv* env, jclass clazz) {
+    return (jlong) EVP_hpke_x25519_hkdf_sha256();
+}
+
+static jlong netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_hkdf_sha256(JNIEnv* env, jclass clazz) {
+    return (jlong) EVP_hpke_hkdf_sha256();
+}
+
+static jlong netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_aes_128_gcm(JNIEnv* env, jclass clazz) {
+    return (jlong) EVP_hpke_aes_128_gcm();
+}
+
+static jlong netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_aes_256_gcm(JNIEnv* env, jclass clazz) {
+    return (jlong) EVP_hpke_aes_256_gcm();
+}
+
+static jlong netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_chacha20_poly1305(JNIEnv* env, jclass clazz) {
+    return (jlong) EVP_hpke_chacha20_poly1305();
+}
+
+static jint netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_DEFAULT_TAG_LENGTH(JNIEnv* env, jclass clazz) {
+    return (jint) EVP_AEAD_DEFAULT_TAG_LENGTH;
+}
+
+static jlong netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_new(JNIEnv* env, jclass clazz) {
+    return (jlong) EVP_HPKE_CTX_new();
+}
+
+static void netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_cleanup(JNIEnv* env, jclass clazz, jlong ctx) {
+    EVP_HPKE_CTX_cleanup((EVP_HPKE_CTX *) ctx);
+}
+
+static void netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_free(JNIEnv* env, jclass clazz, jlong ctx) {
+    EVP_HPKE_CTX_free((EVP_HPKE_CTX *) ctx);
+}
+
+static jbyteArray netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_setup_sender(
+        JNIEnv* env, jclass clazz, jlong ctx, jlong kem, jlong kdf, jlong aead,
+        jbyteArray peer_public_key_bytes, jbyteArray info_bytes) {
+    uint8_t out_enc[EVP_HPKE_MAX_ENC_LENGTH];
+    size_t out_enc_len;
+
+    size_t peer_public_key_len = (size_t) (*env)->GetArrayLength(env, peer_public_key_bytes);
+    const uint8_t *peer_public_key = (const uint8_t*) (*env)->GetByteArrayElements(env, peer_public_key_bytes, 0);
+
+    size_t info_len = (size_t) (*env)->GetArrayLength(env, info_bytes);
+    const uint8_t *info = (const uint8_t*) (*env)->GetByteArrayElements(env, info_bytes, 0);
+
+    int result = EVP_HPKE_CTX_setup_sender((EVP_HPKE_CTX *) ctx, (uint8_t *) out_enc, &out_enc_len, EVP_HPKE_MAX_ENC_LENGTH,
+                                           (const EVP_HPKE_KEM *) kem, (const EVP_HPKE_KDF *) kdf,  (const EVP_HPKE_AEAD *) aead,
+                                           peer_public_key, peer_public_key_len, info, info_len);
+
+    (*env)->ReleaseByteArrayElements(env, peer_public_key_bytes, (jbyte *) peer_public_key, JNI_ABORT);
+    (*env)->ReleaseByteArrayElements(env, info_bytes, (jbyte *) info, JNI_ABORT);
+
+    return to_byte_array(env, result, (const uint8_t *) out_enc, out_enc_len);
+}
+
+static jbyteArray netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
+        JNIEnv* env, jclass clazz, jlong ctx, jlong kem, jlong kdf, jlong aead,
+        jbyteArray peer_public_key_bytes, jbyteArray info_bytes, jbyteArray seed_bytes) {
+    uint8_t out_enc[EVP_HPKE_MAX_ENC_LENGTH];
+    size_t out_enc_len;
+
+    size_t peer_public_key_len = (size_t) (*env)->GetArrayLength(env, peer_public_key_bytes);
+    const uint8_t *peer_public_key = (const uint8_t*) (*env)->GetByteArrayElements(env, peer_public_key_bytes, 0);
+
+    size_t info_len = (size_t) (*env)->GetArrayLength(env, info_bytes);
+    const uint8_t *info = (const uint8_t*) (*env)->GetByteArrayElements(env, info_bytes, 0);
+
+    size_t seed_len = (size_t) (*env)->GetArrayLength(env, seed_bytes);
+    const uint8_t *seed = (const uint8_t*) (*env)->GetByteArrayElements(env, seed_bytes, 0);
+
+    int result = EVP_HPKE_CTX_setup_sender_with_seed_for_testing((EVP_HPKE_CTX *) ctx,  (uint8_t *) out_enc, &out_enc_len, EVP_HPKE_MAX_ENC_LENGTH,
+                                           (const EVP_HPKE_KEM *) kem, (const EVP_HPKE_KDF *) kdf,  (const EVP_HPKE_AEAD *) aead,
+                                           (const uint8_t *) peer_public_key, (size_t) peer_public_key_len, (const uint8_t *) info, (size_t) info_len,
+                                           (const uint8_t *) seed, (size_t) seed_len);
+
+    (*env)->ReleaseByteArrayElements(env, peer_public_key_bytes, (jbyte *) peer_public_key, JNI_ABORT);
+    (*env)->ReleaseByteArrayElements(env, info_bytes, (jbyte *) info, JNI_ABORT);
+    (*env)->ReleaseByteArrayElements(env, seed_bytes, (jbyte *) seed, JNI_ABORT);
+
+    return to_byte_array(env, result, (const uint8_t *) out_enc, out_enc_len);
+}
+
+static jint netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_setup_recipient(
+        JNIEnv* env, jclass clazz, jlong ctx, jlong key, jlong kdf,
+                                                    jlong aead, jbyteArray enc_bytes,
+                                                    jbyteArray info_bytes) {
+    size_t enc_len = (size_t) (*env)->GetArrayLength(env, enc_bytes);
+    const uint8_t *enc = (const uint8_t*) (*env)->GetByteArrayElements(env, enc_bytes, 0);
+    size_t info_len = (size_t) (*env)->GetArrayLength(env, enc_bytes);
+    const uint8_t *info = (const uint8_t*) (*env)->GetByteArrayElements(env, info_bytes, 0);
+
+    int result = EVP_HPKE_CTX_setup_recipient((EVP_HPKE_CTX *) ctx, (const EVP_HPKE_KEY *) key, (const EVP_HPKE_KDF *)kdf,
+                                               (const EVP_HPKE_AEAD *) aead, enc, enc_len, info, info_len);
+
+    (*env)->ReleaseByteArrayElements(env, enc_bytes, (jbyte *) enc, JNI_ABORT);
+    (*env)->ReleaseByteArrayElements(env, info_bytes, (jbyte *) info, JNI_ABORT);
+
+    return result;
+}
+
+static jint netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_open(
+        JNIEnv* env, jclass clazz, jlong ctx, jlong out,
+        jint max_out_len, jlong in, jint in_len, jlong ad, jint ad_len) {
+    size_t out_len;
+
+    int result = EVP_HPKE_CTX_open((EVP_HPKE_CTX *) ctx, (uint8_t *) out, &out_len, (size_t) max_out_len,
+                                   (const uint8_t *) in, (size_t) in_len, (const uint8_t *) ad, (size_t) ad_len);
+    return result == 1 ? (jint) out_len : -1;
+}
+
+static jint netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_seal(
+        JNIEnv* env, jclass clazz, jlong ctx, jlong out,
+        jint max_out_len, jlong in, jint in_len, jlong ad, jint ad_len) {
+    size_t out_len;
+
+    int result = EVP_HPKE_CTX_seal((EVP_HPKE_CTX *) ctx, (uint8_t *) out, &out_len, (size_t) max_out_len,
+                                   (const uint8_t *) in, (size_t) in_len, (const uint8_t *) ad, (size_t) ad_len);
+
+    return result == 1 ? (jint) out_len : -1;
+}
+
+static jint netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_export(
+        JNIEnv* env, jclass clazz, jlong ctx, jlong out,
+        jint secret_len, jlong context, jint context_len) {
+
+    return (jint) EVP_HPKE_CTX_export((const EVP_HPKE_CTX *) ctx, (uint8_t *) out, (size_t) secret_len,
+                                       (const uint8_t *) context, (size_t) context_len);
+}
+
+
+static jint netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_max_overhead(JNIEnv* env, jclass clazz, jlong ctx) {
+    return (jint) EVP_HPKE_CTX_max_overhead((EVP_HPKE_CTX *) ctx);
+}
+
+static jlong netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_new(JNIEnv* env, jclass clazz) {
+    return (jlong) EVP_HPKE_KEY_new();
+}
+
+static void netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_free(JNIEnv* env, jclass clazz, jlong key) {
+    EVP_HPKE_KEY_free((EVP_HPKE_KEY *) key);
+}
+
+static jint netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_init(JNIEnv* env, jclass clazz, jlong key, jlong kem, jbyteArray priv_key_array) {
+    size_t priv_key_len = (size_t)(*env)->GetArrayLength(env, priv_key_array);
+    const uint8_t *priv_key = (const uint8_t*) (*env)->GetByteArrayElements(env, priv_key_array, 0);
+
+    int result = EVP_HPKE_KEY_init((EVP_HPKE_KEY *) key, (const EVP_HPKE_KEM *) kem, priv_key, priv_key_len);
+
+    (*env)->ReleaseByteArrayElements(env, priv_key_array, (jbyte *) priv_key, JNI_ABORT);
+    return (jint) result;
+}
+
+static jbyteArray netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_public_key(JNIEnv* env, jclass clazz, jlong key) {
+    uint8_t out[EVP_HPKE_MAX_PUBLIC_KEY_LENGTH];
+    size_t out_len;
+
+    int result = EVP_HPKE_KEY_public_key((const EVP_HPKE_KEY *) key,  (uint8_t *) out, &out_len, EVP_HPKE_MAX_PUBLIC_KEY_LENGTH);
+    return to_byte_array(env, result, (const uint8_t *) out, out_len);
+}
+
+static jbyteArray netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_private_key(JNIEnv* env, jclass clazz, jlong key) {
+    uint8_t out[EVP_HPKE_MAX_PRIVATE_KEY_LENGTH];
+    size_t out_len;
+
+    int result = EVP_HPKE_KEY_private_key((const EVP_HPKE_KEY *) key, (uint8_t *) out, &out_len, EVP_HPKE_MAX_PRIVATE_KEY_LENGTH);
+    return to_byte_array(env, result, (const uint8_t *) out, out_len);
+}
+
+static jint netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEM_public_key_len(JNIEnv* env, jclass clazz, jlong kem) {
+    return (jint) EVP_HPKE_KEM_public_key_len((EVP_HPKE_KEM *) kem);
+}
+
+static jlong netty_incubator_codec_ohttp_hpke_boringssl_memory_address(JNIEnv* env, jclass clazz, jobject buffer) {
+    return (jlong) (*env)->GetDirectBufferAddress(env, buffer);
+}
+
+
+static jint netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_key_length(JNIEnv* env, jclass clazz, jlong aead) {
+    return (jint) EVP_AEAD_key_length((EVP_AEAD *) aead);
+}
+static jint netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_nonce_length(JNIEnv* env, jclass clazz, jlong aead) {
+    return (jint) EVP_AEAD_nonce_length((EVP_AEAD *) aead);
+}
+static jint netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_max_overhead(JNIEnv* env, jclass clazz, jlong aead) {
+    return (jint) EVP_AEAD_max_overhead((EVP_AEAD *) aead);
+}
+static jint netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_max_tag_len(JNIEnv* env, jclass clazz, jlong aead) {
+    return (jint) EVP_AEAD_max_tag_len((EVP_AEAD *) aead);
+}
+
+static jlong netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_CTX_new(JNIEnv* env, jclass clazz, jlong aead, jbyteArray key_array, jint tag_len) {
+    size_t key_len = (size_t)(*env)->GetArrayLength(env, key_array);
+    const uint8_t *key = (const uint8_t*) (*env)->GetByteArrayElements(env, key_array, 0);
+
+    EVP_AEAD_CTX* ctx = EVP_AEAD_CTX_new((const EVP_AEAD *) aead, key, key_len, (size_t) tag_len);
+
+    (*env)->ReleaseByteArrayElements(env, key_array, (jbyte *) key, JNI_ABORT);
+    return (jlong) ctx;
+}
+
+static void netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_CTX_cleanup(JNIEnv* env, jclass clazz, jlong ctx) {
+    EVP_AEAD_CTX_cleanup((EVP_AEAD_CTX *) ctx);
+}
+
+static void netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_CTX_free(JNIEnv* env, jclass clazz, jlong ctx) {
+    EVP_AEAD_CTX_free((EVP_AEAD_CTX *) ctx);
+}
+
+static jint netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_CTX_seal(JNIEnv* env, jclass clazz, jlong ctx,
+                                                                         jlong out, jint max_out_len, jlong nonce, jint nonce_len,
+                                                                         jlong in, jint in_len, jlong ad, jint ad_len) {
+
+    size_t out_len;
+    int result = EVP_AEAD_CTX_seal((const EVP_AEAD_CTX *) ctx, (uint8_t *) out, &out_len, (size_t) max_out_len,
+                                   (const uint8_t *) nonce, (size_t) nonce_len,
+                                   (const uint8_t *) in, (size_t) in_len,
+                                   (const uint8_t *) ad, (size_t) ad_len);
+
+    return result == 1 ? (jint) out_len : -1;
+}
+
+static jint netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_CTX_open(JNIEnv* env, jclass clazz, jlong ctx,
+                                                                         jlong out, jint max_out_len, jlong nonce, jint nonce_len,
+                                                                         jlong in, jint in_len, jlong ad, jint ad_len) {
+
+    size_t out_len;
+    int result = EVP_AEAD_CTX_open((const EVP_AEAD_CTX *) ctx, (uint8_t *) out,  &out_len, (size_t) max_out_len,
+                                   (const uint8_t *) nonce, (size_t) nonce_len,
+                                   (const uint8_t *) in, (size_t) in_len,
+                                   (const uint8_t *) ad, (size_t) ad_len);
+
+    return result == 1 ? (jint) out_len : -1;
+}
+
+// JNI Registered Methods End
+
+// JNI Method Registration Table Begin
+static const JNINativeMethod statically_referenced_fixed_method_table[] = {
+  { "EVP_hpke_x25519_hkdf_sha256", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_x25519_hkdf_sha256 },
+  { "EVP_hpke_hkdf_sha256", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_hkdf_sha256 },
+  { "EVP_hpke_aes_128_gcm", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_aes_128_gcm },
+  { "EVP_hpke_aes_256_gcm", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_aes_256_gcm },
+  { "EVP_hpke_chacha20_poly1305", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_chacha20_poly1305 },
+  { "EVP_AEAD_DEFAULT_TAG_LENGTH", "()I", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_DEFAULT_TAG_LENGTH }
+};
+
+static const jint statically_referenced_fixed_method_table_size = sizeof(statically_referenced_fixed_method_table) / sizeof(statically_referenced_fixed_method_table[0]);
+static const JNINativeMethod fixed_method_table[] = {
+  { "EVP_HPKE_CTX_new", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_new },
+  { "EVP_HPKE_CTX_cleanup", "(J)V", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_cleanup },
+  { "EVP_HPKE_CTX_free", "(J)V", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_free },
+  { "EVP_HPKE_CTX_setup_sender", "(JJJJ[B[B)[B", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_setup_sender },
+  { "EVP_HPKE_CTX_setup_sender_with_seed_for_testing", "(JJJJ[B[B[B)[B", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_setup_sender_with_seed_for_testing },
+  { "EVP_HPKE_CTX_setup_recipient", "(JJJJ[B[B)I", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_setup_recipient },
+  { "EVP_HPKE_CTX_open", "(JJIJIJI)I", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_open },
+  { "EVP_HPKE_CTX_seal", "(JJIJIJI)I", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_seal },
+  { "EVP_HPKE_CTX_export", "(JJIJI)I", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_export },
+  { "EVP_HPKE_CTX_max_overhead", "(J)I", (void * ) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_max_overhead },
+  { "EVP_HPKE_KEY_new", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_new },
+  { "EVP_HPKE_KEY_free", "(J)V", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_free },
+  { "EVP_HPKE_KEY_init", "(JJJI)I", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_init },
+  { "EVP_HPKE_KEY_public_key", "(J)[B", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_public_key },
+  { "EVP_HPKE_KEY_private_key", "(J)[B", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_private_key },
+  { "EVP_HPKE_KEM_public_key_len", "(J)I", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEM_public_key_len },
+  { "memory_address", "(Ljava/nio/ByteBuffer;)J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_memory_address },
+
+  { "EVP_AEAD_key_length", "(J)I", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_key_length },
+  { "EVP_AEAD_nonce_length", "(J)I", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_nonce_length },
+  { "EVP_AEAD_max_overhead", "(J)I", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_max_overhead },
+  { "EVP_AEAD_max_tag_len", "(J)I", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_max_tag_len },
+
+  { "EVP_AEAD_CTX_new", "(J[BI)J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_CTX_new },
+  { "EVP_AEAD_CTX_cleanup", "(J)V", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_CTX_cleanup },
+  { "EVP_AEAD_CTX_free", "(J)V", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_CTX_free },
+  { "EVP_AEAD_CTX_seal", "(JJIJIJIJI)I", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_CTX_seal },
+  { "EVP_AEAD_CTX_open", "(JJIJIJIJI)I", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_CTX_open }
+
+};
+
+static const jint fixed_method_table_size = sizeof(fixed_method_table) / sizeof(fixed_method_table[0]);
+
+// JNI Method Registration Table End
+
+// IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
+//            Quiche to reflect that.
+static jint netty_incubator_codec_ohttp_hpke_boringssl_JNI_OnLoad(JNIEnv* env, char const* packagePrefix) {
+    int ret = JNI_ERR;
+    int staticallyRegistered = 0;
+    int nativeRegistered = 0;
+
+    // We must register the statically referenced methods first!
+    if (netty_jni_util_register_natives(env,
+            packagePrefix,
+            STATICALLY_CLASSNAME,
+            statically_referenced_fixed_method_table,
+            statically_referenced_fixed_method_table_size) != 0) {
+        goto done;
+    }
+    staticallyRegistered = 1;
+
+    if (netty_jni_util_register_natives(env,
+            packagePrefix,
+            BORINGSSL_CLASSNAME,
+            fixed_method_table,
+            fixed_method_table_size) != 0) {
+        goto done;
+    }
+    nativeRegistered = 1;
+
+    // Initialize this module
+
+    staticPackagePrefix = packagePrefix;
+
+    ret = NETTY_JNI_UTIL_JNI_VERSION;
+done:
+    if (ret == JNI_ERR) {
+        if (staticallyRegistered == 1) {
+            netty_jni_util_unregister_natives(env, packagePrefix, STATICALLY_CLASSNAME);
+        }
+        if (nativeRegistered == 1) {
+            netty_jni_util_unregister_natives(env, packagePrefix, BORINGSSL_CLASSNAME);
+        }
+    }
+    return ret;
+}
+
+static void netty_incubator_codec_ohttp_hpke_boringssl_JNI_OnUnload(JNIEnv* env) {
+    netty_jni_util_unregister_natives(env, staticPackagePrefix, STATICALLY_CLASSNAME);
+    netty_jni_util_unregister_natives(env, staticPackagePrefix, BORINGSSL_CLASSNAME);
+    free((void*) staticPackagePrefix);
+    staticPackagePrefix = NULL;
+}
+
+// Invoked by the JVM when statically linked
+
+// We build with -fvisibility=hidden so ensure we mark everything that needs to be visible with JNIEXPORT
+// https://mail.openjdk.java.net/pipermail/core-libs-dev/2013-February/014549.html
+
+// Invoked by the JVM when statically linked
+JNIEXPORT jint JNI_OnLoad_netty_incubator_codec_ohttp_hpke_boringssl(JavaVM* vm, void* reserved) {
+    return netty_jni_util_JNI_OnLoad(vm, reserved, LIBRARYNAME, netty_incubator_codec_ohttp_hpke_boringssl_JNI_OnLoad);
+}
+
+// Invoked by the JVM when statically linked
+JNIEXPORT void JNI_OnUnload_netty_incubator_codec_ohttp_hpke_boringssl(JavaVM* vm, void* reserved) {
+    netty_jni_util_JNI_OnUnload(vm, reserved, netty_incubator_codec_ohttp_hpke_boringssl_JNI_OnUnload);
+}
+
+#ifndef NETTY_OHTTP_HPKE_BORINGSSL_BUILD_STATIC
+JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
+    return netty_jni_util_JNI_OnLoad(vm, reserved, LIBRARYNAME, netty_incubator_codec_ohttp_hpke_boringssl_JNI_OnLoad);
+}
+
+JNIEXPORT void JNI_OnUnload(JavaVM* vm, void* reserved) {
+    netty_jni_util_JNI_OnUnload(vm, reserved, netty_incubator_codec_ohttp_hpke_boringssl_JNI_OnUnload);
+}
+#endif /* NETTY_OHTTP_HPKE_BORINGSSL_BUILD_STATIC */

--- a/codec-ohttp-hpke-native-boringssl/src/main/c/netty_incubator_codec_ohttp_hpke_boringssl.h
+++ b/codec-ohttp-hpke-native-boringssl/src/main/c/netty_incubator_codec_ohttp_hpke_boringssl.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef NETTY_OHTTP_HPKE_BORINGSSL_H_
+#define NETTY_OHTTP_HPKE_BORINGSSL_H_
+
+
+#endif /* NETTY_OHTTP_HPKE_BORINGSSL_H_ */

--- a/codec-ohttp-hpke-native-boringssl/src/main/native-package/m4/custom.m4.template
+++ b/codec-ohttp-hpke-native-boringssl/src/main/native-package/m4/custom.m4.template
@@ -29,7 +29,7 @@ AC_DEFUN([CUSTOM_M4_SETUP],
       esac
 
   dnl Update the compiler/linker flags
-  CFLAGS="$CFLAGS -std=gnu99 -fvisibility=hidden -Werror -fno-omit-frame-pointer -Wunused -Wno-unused-value -O3 -I@BORINGSSL_INCLUDE_DIR@ -I@QUICHE_INCLUDE_DIR@ @EXTRA_CFLAGS@"
+  CFLAGS="$CFLAGS -std=gnu99 -fvisibility=hidden -Werror -fno-omit-frame-pointer -Wunused -Wno-unused-value -O3 -I@BORINGSSL_INCLUDE_DIR@ @EXTRA_CFLAGS@"
   CXXFLAGS="$CXXFLAGS"
   LDFLAGS="$LDFLAGS -L@BORINGSSL_LIB_DIR@ -lcrypto @EXTRA_LDFLAGS@"
   AC_SUBST(CFLAGS)

--- a/codec-ohttp-hpke-native-boringssl/src/main/native-package/m4/custom.m4.template
+++ b/codec-ohttp-hpke-native-boringssl/src/main/native-package/m4/custom.m4.template
@@ -1,0 +1,39 @@
+dnl ---------------------------------------------------------------------------
+dnl  Copyright 2023 The Netty Project
+dnl
+dnl  Licensed under the Apache License, Version 2.0 (the "License");
+dnl  you may not use this file except in compliance with the License.
+dnl  You may obtain a copy of the License at
+dnl
+dnl     http://www.apache.org/licenses/LICENSE-2.0
+dnl
+dnl  Unless required by applicable law or agreed to in writing, software
+dnl  distributed under the License is distributed on an "AS IS" BASIS,
+dnl  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+dnl  See the License for the specific language governing permissions and
+dnl  limitations under the License.
+dnl ---------------------------------------------------------------------------
+
+AC_DEFUN([CUSTOM_M4_SETUP],
+[
+  dnl Ensure we only expose what we really need
+  case $host in
+      *-darwin*)
+          LDFLAGS="$LDFLAGS -Wl,-exported_symbol,_JNI_*"
+          ;;
+      *linux*)
+          LDFLAGS="$LDFLAGS -Wl,--exclude-libs,ALL"
+          ;;
+      *)
+          ;;
+      esac
+
+  dnl Update the compiler/linker flags
+  CFLAGS="$CFLAGS -std=gnu99 -fvisibility=hidden -Werror -fno-omit-frame-pointer -Wunused -Wno-unused-value -O3 -I@BORINGSSL_INCLUDE_DIR@ -I@QUICHE_INCLUDE_DIR@ @EXTRA_CFLAGS@"
+  CXXFLAGS="$CXXFLAGS"
+  LDFLAGS="$LDFLAGS -L@BORINGSSL_LIB_DIR@ -lssl -lcrypto @EXTRA_LDFLAGS@"
+  AC_SUBST(CFLAGS)
+  AC_SUBST(CXXFLAGS)
+  AC_SUBST(LDFLAGS)
+])
+

--- a/codec-ohttp-hpke-native-boringssl/src/main/native-package/m4/custom.m4.template
+++ b/codec-ohttp-hpke-native-boringssl/src/main/native-package/m4/custom.m4.template
@@ -31,7 +31,7 @@ AC_DEFUN([CUSTOM_M4_SETUP],
   dnl Update the compiler/linker flags
   CFLAGS="$CFLAGS -std=gnu99 -fvisibility=hidden -Werror -fno-omit-frame-pointer -Wunused -Wno-unused-value -O3 -I@BORINGSSL_INCLUDE_DIR@ -I@QUICHE_INCLUDE_DIR@ @EXTRA_CFLAGS@"
   CXXFLAGS="$CXXFLAGS"
-  LDFLAGS="$LDFLAGS -L@BORINGSSL_LIB_DIR@ -lssl -lcrypto @EXTRA_LDFLAGS@"
+  LDFLAGS="$LDFLAGS -L@BORINGSSL_LIB_DIR@ -lcrypto @EXTRA_LDFLAGS@"
   AC_SUBST(CFLAGS)
   AC_SUBST(CXXFLAGS)
   AC_SUBST(LDFLAGS)

--- a/codec-ohttp-hpke-native-boringssl/src/main/native-package/vs2010.custom.props.template
+++ b/codec-ohttp-hpke-native-boringssl/src/main/native-package/vs2010.custom.props.template
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2023 The Netty Project
+  ~
+  ~ The Netty Project licenses this file to you under the Apache License,
+  ~ version 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at:
+  ~
+  ~   https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(JAVA_HOME)\include;$(JAVA_HOME)\include\win32;@BORINGSSL_INCLUDE_DIR@;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>ntdll.lib;ws2_32.lib;crypt32.lib;bcrypt.lib;userenv.lib;@BORINGSSL_LIB_DIR@\@SSL_LIB@;@BORINGSSL_LIB_DIR@\@CRYPTO_LIB@;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+</Project>

--- a/codec-ohttp-hpke-native-boringssl/src/main/native-package/vs2010.custom.props.template
+++ b/codec-ohttp-hpke-native-boringssl/src/main/native-package/vs2010.custom.props.template
@@ -20,7 +20,7 @@
       <AdditionalIncludeDirectories>$(JAVA_HOME)\include;$(JAVA_HOME)\include\win32;@BORINGSSL_INCLUDE_DIR@;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>ntdll.lib;ws2_32.lib;crypt32.lib;bcrypt.lib;userenv.lib;@BORINGSSL_LIB_DIR@\@SSL_LIB@;@BORINGSSL_LIB_DIR@\@CRYPTO_LIB@;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ntdll.lib;ws2_32.lib;crypt32.lib;bcrypt.lib;userenv.lib;@BORINGSSL_LIB_DIR@\@CRYPTO_LIB@;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 </Project>

--- a/codec-ohttp-hpke-native-boringssl/src/test/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLOHttpCryptoProviderTest.java
+++ b/codec-ohttp-hpke-native-boringssl/src/test/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLOHttpCryptoProviderTest.java
@@ -1,0 +1,11 @@
+package io.netty.incubator.codec.hpke.boringssl;
+
+import org.junit.jupiter.api.Test;
+
+public class BoringSSLOHttpCryptoProviderTest {
+
+    @Test
+    void canBeLoaded() {
+        BoringSSLHPKE.ensureAvailability();
+    }
+}

--- a/codec-ohttp-hpke-native-boringssl/src/test/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLOHttpCryptoProviderTest.java
+++ b/codec-ohttp-hpke-native-boringssl/src/test/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLOHttpCryptoProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package io.netty.incubator.codec.hpke.boringssl;
 
 import org.junit.jupiter.api.Test;

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/OHttpCryptoProvider.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/OHttpCryptoProvider.java
@@ -15,6 +15,8 @@
  */
 package io.netty.incubator.codec.hpke;
 
+import java.util.List;
+
 /**
  * Provides methods to handle <a href="https://www.rfc-editor.org/rfc/rfc9180.html">Hybrid Public Key Encryption</a>
  * for oHTTP. Because of that the functionality is limited to what is needed for oHTTP.
@@ -79,6 +81,34 @@ public interface OHttpCryptoProvider {
      * @return                  the deserialized {@link AsymmetricKeyParameter}.
      */
     AsymmetricKeyParameter deserializePublicKey(KEM kem, byte[] publicKeyBytes);
+
+    /**
+     * Returns an immutable {@link List} of all supported {@link AEAD}s.
+     *
+     * @return supported {@link AEAD}s.
+     */
+    List<AEAD> supportedAEAD();
+
+    /**
+     * Returns an immutable {@link List} of all supported {@link KEM}s.
+     *
+     * @return supported {@link KEM}s.
+     */
+    List<KEM> supportedKEM();
+
+    /**
+     * Returns an immutable {@link List} of all supported {@link KDF}s.
+     *
+     * @return supported {@link KDF}s.
+     */
+    List<KDF> supportedKDF();
+
+    /**
+     * Returns an immutable {@link List} of all supported {@link Mode}s.
+     *
+     * @return supported {@link Mode}s.
+     */
+    List<Mode> supportedMode();
 
     /**
      * <a href="https://www.rfc-editor.org/rfc/rfc9180.html#name-hybrid-public-key-encryptio">Hybrid Public Key Encryption</a>

--- a/codec-ohttp/pom.xml
+++ b/codec-ohttp/pom.xml
@@ -129,7 +129,7 @@
     <profile>
       <id>linux-aarch64</id>
       <properties>
-        <netty.hpke.boringssl.classifier>linux-aarch64</netty.hpke.boringssl.classifier>
+        <netty.hpke.boringssl.classifier>linux-aarch_64</netty.hpke.boringssl.classifier>
       </properties>
     </profile>
   </profiles>

--- a/codec-ohttp/pom.xml
+++ b/codec-ohttp/pom.xml
@@ -29,6 +29,7 @@
 
   <properties>
     <javaModuleName>io.netty.incubator.codec.ohttp</javaModuleName>
+    <netty.hpke.boringssl.classifier>${os.detected.name}-${os.detected.arch}</netty.hpke.boringssl.classifier>
   </properties>
 
   <build>
@@ -107,6 +108,19 @@
       <groupId>io.netty.incubator</groupId>
       <artifactId>netty-incubator-codec-ohttp-hpke-bouncycastle</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty.incubator</groupId>
+      <artifactId>netty-incubator-codec-ohttp-hpke-classes-boringssl</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty.incubator</groupId>
+      <artifactId>netty-incubator-codec-ohttp-hpke-native-boringssl</artifactId>
+      <version>${project.version}</version>
+      <classifier>${netty.hpke.boringssl.classifier}</classifier>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/codec-ohttp/pom.xml
+++ b/codec-ohttp/pom.xml
@@ -124,4 +124,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>linux-aarch64</id>
+      <properties>
+        <netty.hpke.boringssl.classifier>linux-aarch64</netty.hpke.boringssl.classifier>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/codec-ohttp/pom.xml
+++ b/codec-ohttp/pom.xml
@@ -132,5 +132,11 @@
         <netty.hpke.boringssl.classifier>linux-aarch_64</netty.hpke.boringssl.classifier>
       </properties>
     </profile>
+    <profile>
+      <id>mac-intel-cross-compile</id>
+      <properties>
+        <netty.hpke.boringssl.classifier>osx-x86_64</netty.hpke.boringssl.classifier>
+      </properties>
+    </profile>
   </profiles>
 </project>

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCrypto.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCrypto.java
@@ -78,7 +78,14 @@ public abstract class OHttpCrypto implements AutoCloseable {
 
     @Override
     public void close()  {
-        encryptCrypto().close();
-        decryptCrypto().close();
+        // Check for null as these could be null if the constructor did throw.
+        CryptoEncryptContext encryptContext = encryptCrypto();
+        if (encryptContext != null) {
+            encryptContext.close();
+        }
+        CryptoDecryptContext decryptContext = decryptCrypto();
+        if (decryptContext != null) {
+            decryptContext.close();;
+        }
     }
 }

--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -1,19 +1,43 @@
 FROM centos:7
 
 ENV SOURCE_DIR /root/source
+ENV LIBS_DIR /root/libs
+ENV CMAKE_VERSION_BASE 3.26
+ENV CMAKE_VERSION $CMAKE_VERSION_BASE.4
+ENV NINJA_VERSION 1.7.2
+ENV GO_VERSION 1.9.3
+ENV MAVEN_VERSION 3.9.1
 
 # install dependencies
 RUN yum install -y \
+ apr-devel \
+ autoconf \
+ automake \
  bzip2 \
  git \
+ glibc-devel \
  gnupg \
+ libtool \
+ lsb-core \
+ make \
+ perl \
  tar \
  unzip \
  wget \
- zip
+ zip \
+ zlib-devel
 
 RUN mkdir $SOURCE_DIR
 WORKDIR $SOURCE_DIR
+
+RUN yum install -y centos-release-scl
+
+RUN yum -y install devtoolset-11-gcc devtoolset-11-gcc-c++
+RUN echo 'source /opt/rh/devtoolset-11/enable' >> ~/.bashrc
+
+RUN wget -q https://github.com/ninja-build/ninja/releases/download/v$NINJA_VERSION/ninja-linux.zip && unzip ninja-linux.zip && mkdir -p /opt/ninja-$NINJA_VERSION/bin && mv ninja /opt/ninja-$NINJA_VERSION/bin && echo 'PATH=/opt/ninja-$NINJA_VERSION/bin:$PATH' >> ~/.bashrc
+RUN wget -q https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz && tar zxf go$GO_VERSION.linux-amd64.tar.gz && mv go /opt/ && echo 'PATH=/opt/go/bin:$PATH' >> ~/.bashrc && echo 'export GOROOT=/opt/go/' >> ~/.bashrc
+RUN curl -s https://cmake.org/files/v$CMAKE_VERSION_BASE/cmake-$CMAKE_VERSION-linux-x86_64.tar.gz --output cmake-$CMAKE_VERSION-linux-x86_64.tar.gz && tar zvxf cmake-$CMAKE_VERSION-linux-x86_64.tar.gz && mv cmake-$CMAKE_VERSION-linux-x86_64 /opt/ && echo 'PATH=/opt/cmake-$CMAKE_VERSION-linux-x86_64/bin:$PATH' >> ~/.bashrc
 
 # Downloading and installing SDKMAN!
 RUN curl -s "https://get.sdkman.io" | bash
@@ -24,8 +48,21 @@ ENV JAVA_VERSION $java_version
 # Installing Java removing some unnecessary SDKMAN files
 RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \
     yes | sdk install java $JAVA_VERSION && \
+    yes | sdk install maven $MAVEN_VERSION && \
     rm -rf $HOME/.sdkman/archives/* && \
     rm -rf $HOME/.sdkman/tmp/*"
 
 RUN echo 'export JAVA_HOME="/root/.sdkman/candidates/java/current"' >> ~/.bashrc
 RUN echo 'PATH=$JAVA_HOME/bin:$PATH' >> ~/.bashrc
+
+# Prepare our own build
+ENV PATH /root/.sdkman/candidates/maven/current:$PATH
+ENV JAVA_HOME /root/.sdkman/candidates/java/
+
+# Cleanup
+RUN rm -rf $SOURCE_DIR
+RUN yum clean all && \
+    rm -rf /var/cache/yum
+
+# when the JDK is GraalVM install native-image
+RUN if [ -O /root/.sdkman/candidates/java/current/bin/gu ]; then /root/.sdkman/candidates/java/current/bin/gu install native-image; else echo "Not GraalVM, skip installation of native-image" ; fi

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -1,0 +1,65 @@
+FROM centos:7.6.1810
+
+ARG GCC_VERSION=10.2-2020.11
+ENV MAVEN_VERSION 3.9.1
+ENV SOURCE_DIR /root/source
+ENV WORKSPACE_DIR /root/workspace
+ENV PROJECT_DIR /root/workspace/project
+
+# We want to have git 2.x for the maven scm plugin and also for boringssl
+RUN yum install -y http://opensource.wandisco.com/centos/6/git/x86_64/wandisco-git-release-6-1.noarch.rpm
+
+RUN yum -y install epel-release
+
+# Install requirements
+RUN yum install -y \
+ apr-devel \
+ autoconf \
+ automake \
+ bzip2 \
+ git \
+ glibc-devel \
+ golang \
+ gnupg \
+ libtool \
+ lsb-core \
+ ninja-build \
+ make \
+ perl \
+ tar \
+ unzip \
+ wget \
+ zip
+
+
+RUN mkdir $SOURCE_DIR
+WORKDIR $SOURCE_DIR
+
+# Install Java
+RUN yum install -y java-1.8.0-openjdk-devel golang
+ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk/"
+
+# Install aarch64 gcc 10.2 toolchain
+RUN wget https://developer.arm.com/-/media/Files/downloads/gnu-a/$GCC_VERSION/binrel/gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu.tar.xz && \
+  tar xvf gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu.tar.xz && mv gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu /opt/
+ENV PATH="/opt/gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu/bin:${PATH}"
+
+# Install CMake
+RUN yum install -y cmake3 && ln -s /usr/bin/cmake3 /usr/bin/cmake
+
+# Downloading and installing SDKMAN!
+RUN curl -s "https://get.sdkman.io" | bash
+
+# Installing Java and Maven, removing some unnecessary SDKMAN files
+RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \
+    yes | sdk install maven $MAVEN_VERSION && \
+    rm -rf $HOME/.sdkman/archives/* && \
+    rm -rf $HOME/.sdkman/tmp/*"
+
+# Cleanup
+RUN rm -rf $SOURCE_DIR
+RUN yum clean all && \
+    rm -rf /var/cache/yum
+
+# Prepare our own build
+ENV PATH /root/.sdkman/candidates/maven/current:$PATH

--- a/docker/docker-compose.centos-7-cross.yaml
+++ b/docker/docker-compose.centos-7-cross.yaml
@@ -1,0 +1,80 @@
+version: "3"
+
+services:
+
+  cross-compile-aarch64-runtime-setup:
+    image: netty-codec-ohttp-centos:cross_compile_aarch64
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile.cross_compile_aarch64
+      args:
+        gcc_version: "10.2-2020.11"
+
+  cross-compile-aarch64-common: &cross-compile-aarch64-common
+    image: netty-codec-ohttp-centos:cross_compile_aarch64
+    depends_on: [cross-compile-aarch64-runtime-setup]
+    environment:
+      - GPG_KEYNAME
+      - GPG_PASSPHRASE
+      - GPG_PRIVATE_KEY
+      - MAVEN_OPTS
+    volumes:
+      - ~/.ssh:/root/.ssh:delegated
+      - ~/.gnupg:/root/.gnupg:delegated
+      - ~/.m2/repository:/root/.m2/repository
+      - ..:/code:delegated
+    working_dir: /code
+
+  cross-compile-aarch64-shell:
+    <<: *cross-compile-aarch64-common
+    volumes:
+      - ~/.ssh:/root/.ssh:delegated
+      - ~/.gnupg:/root/.gnupg:delegated
+      - ~/.m2:/root/.m2:delegated
+      - ~/.gitconfig:/root/.gitconfig:delegated
+      - ~/.gitignore:/root/.gitignore:delegated
+      - ..:/code:delegated
+    entrypoint: /bin/bash
+
+  cross-compile-aarch64-build:
+    <<: *cross-compile-aarch64-common
+    command: /bin/bash -cl "./mvnw -B -ntp clean package -Plinux-aarch64 -DskipTests"
+
+  cross-compile-aarch64-deploy:
+    <<: *cross-compile-aarch64-common
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.gnupg:/root/.gnupg
+      - ~/.m2/repository:/root/.m2/repository
+      - ~/.m2/settings.xml:/root/.m2/settings.xml
+    command: /bin/bash -cl "./mvnw -B -ntp clean deploy -Plinux-aarch64 -DskipTests"
+
+  cross-compile-aarch64-stage-snapshot:
+    <<: *cross-compile-aarch64-common
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.gnupg:/root/.gnupg
+      - ~/.m2/repository:/root/.m2/repository
+      - ~/.m2/settings.xml:/root/.m2/settings.xml
+      - ~/local-staging:/root/local-staging
+      - ..:/code
+    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-aarch64 clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
+
+  cross-compile-aarch64-stage-release:
+    <<: *cross-compile-aarch64-common
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.m2/settings.xml:/root/.m2/settings.xml
+      - ~/.m2/repository:/root/.m2/repository
+      - ~/local-staging:/root/local-staging
+      - ..:/code
+    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -ntp -Plinux-aarch64 clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
+
+  cross-compile-aarch64-install:
+    <<: *cross-compile-aarch64-common
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.gnupg:/root/.gnupg
+      - ~/.m2:/root/.m2
+      - ..:/code
+    command: /bin/bash -cl "./mvnw -B -ntp clean install -Plinux-aarch64 -DskipTests=true"

--- a/docker/docker-compose.centos-7.117.yaml
+++ b/docker/docker-compose.centos-7.117.yaml
@@ -1,0 +1,36 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty-codec-ohttp-centos7:centos-7-17
+    build:
+      args:
+        java_version : "17.0.9-zulu"
+
+  build:
+    image: netty-codec-ohttp-centos7:centos-7-17
+
+  build-leak:
+    image: netty-codec-ohttp-centos7:centos-7-17
+
+  build-no-unsafe:
+    image: netty-codec-ohttp-centos7:centos-7-17
+
+  build-clean:
+    image: netty-codec-ohttp-centos7:centos-7-17
+
+  deploy:
+    image: netty-codec-ohttp-centos7:centos-7-17
+
+  deploy-clean:
+    image: netty-codec-ohttp-centos7:centos-7-17
+
+  stage-snapshot:
+    image: netty-codec-ohttp-centos7:centos-7-17
+
+  stage-release:
+    image: netty-codec-ohttp-centos7:centos-7-17
+
+  shell:
+    image: netty-codec-ohttp-centos7:centos-7-17

--- a/docker/docker-compose.centos-7.18.yaml
+++ b/docker/docker-compose.centos-7.18.yaml
@@ -14,7 +14,22 @@ services:
   build-leak:
     image: netty-codec-ohttp-centos7:centos-7-1.8
 
+  build-no-unsafe:
+    image: netty-codec-ohttp-centos7:centos-7-1.8
+
+  build-clean:
+    image: netty-codec-ohttp-centos7:centos-7-1.8
+
   deploy:
+    image: netty-codec-ohttp-centos7:centos-7-1.8
+
+  deploy-clean:
+    image: netty-codec-ohttp-centos7:centos-7-1.8
+
+  stage-snapshot:
+    image: netty-codec-ohttp-centos7:centos-7-1.8
+
+  stage-release:
     image: netty-codec-ohttp-centos7:centos-7-1.8
 
   shell:

--- a/docker/docker-compose.centos-7.21.yaml
+++ b/docker/docker-compose.centos-7.21.yaml
@@ -1,0 +1,36 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty-codec-ohttp-centos7:centos-7-21
+    build:
+      args:
+        java_version : "21.0.1-zulu"
+
+  build:
+    image: netty-codec-ohttp-centos7:centos-7-21
+
+  build-leak:
+    image: netty-codec-ohttp-centos7:centos-7-21
+
+  build-no-unsafe:
+    image: netty-codec-ohttp-centos7:centos-7-21
+
+  build-clean:
+    image: netty-codec-ohttp-centos7:centos-7-21
+
+  deploy:
+    image: netty-codec-ohttp-centos7:centos-7-21
+
+  deploy-clean:
+    image: netty-codec-ohttp-centos7:centos-7-21
+
+  stage-snapshot:
+    image: netty-codec-ohttp-centos7:centos-7-21
+
+  stage-release:
+    image: netty-codec-ohttp-centos7:centos-7-21
+
+  shell:
+    image: netty-codec-ohttp-centos7:centos-7-21

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -17,29 +17,68 @@ services:
       - GPG_PRIVATE_KEY
       - MAVEN_OPTS
     volumes:
+      - ~/.m2/repository:/root/.m2/repository
       - ~/.ssh:/root/.ssh:delegated
       - ~/.gnupg:/root/.gnupg:delegated
-      - ~/.m2/repository:/root/.m2/repository
       - ..:/code:delegated
     working_dir: /code
 
   build:
     <<: *common
-    command: /bin/bash -cl "./mvnw clean package"
+    command: /bin/bash -cl "./mvnw -B -ntp clean package"
 
   build-leak:
     <<: *common
-    command: /bin/bash -cl "./mvnw -Pleak clean package"
+    command: /bin/bash -cl "./mvnw -B -ntp -Pleak clean package"
+
+  build-no-unsafe:
+    <<: *common
+    command: /bin/bash -cl "./mvnw -B -ntp -PnoUnsafe clean package"
+
+  build-clean:
+    <<: *common
+    command: /bin/bash -cl "./mvnw -B -ntp clean package"
 
   deploy:
     <<: *common
-    command: /bin/bash -cl "./mvnw clean deploy -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -B -ntp clean deploy -DskipTests=true"
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg
       - ~/.m2/repository:/root/.m2/repository
       - ~/.m2/settings.xml:/root/.m2/settings.xml
       - ..:/code
+
+  deploy-clean:
+    <<: *common
+    command: /bin/bash -cl "./mvnw -B -ntp clean deploy -DskipTests=true"
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.gnupg:/root/.gnupg
+      - ~/.m2/repository:/root/.m2/repository
+      - ~/.m2/settings.xml:/root/.m2/settings.xml
+      - ..:/code
+
+  stage-snapshot:
+    <<: *common
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.gnupg:/root/.gnupg
+      - ~/.m2/settings.xml:/root/.m2/settings.xml
+      - ~/.m2/repository:/root/.m2/repository
+      - ~/local-staging:/root/local-staging
+      - ..:/code
+    command: /bin/bash -cl "./mvnw -B -ntp clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
+
+  stage-release:
+    <<: *common
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.m2/settings.xml:/root/.m2/settings.xml
+      - ~/.m2/repository:/root/.m2/repository
+      - ~/local-staging:/root/local-staging
+      - ..:/code
+    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -ntp clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
 
   shell:
     <<: *common

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,8 @@
     <module>codec-bhttp</module>
     <module>codec-ohttp-hpke</module>
     <module>codec-ohttp-hpke-bouncycastle</module>
+    <module>codec-ohttp-hpke-classes-boringssl</module>
+    <module>codec-ohttp-hpke-native-boringssl</module>
   </modules>
   <properties>
     <javaModuleName />

--- a/scripts/finish_release.sh
+++ b/scripts/finish_release.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+
+if [ -z "$JAVA8_HOME" ]; then
+    echo "The JAVA8_HOME environment variable needs to be set"
+    exit 1
+fi
+
+if [ "$#" -ne 2 ]; then
+    echo "Expected staging profile id and tag, login into oss.sonatype.org to retrieve it"
+    exit 1
+fi
+
+OS=$(uname)
+ARCH=$(uname -p)
+if [ "$OS" != "Darwin" ]; then
+    echo "Needs to be executed on macOS"
+    exit 1
+fi
+
+BRANCH=$(git branch --show-current)
+
+if git tag | grep -q "$2" ; then
+    echo "Tag $2 already existed locally, deleting it"
+    git tag -d "$2"
+fi
+
+CROSS_COMPILE_PROFILE="mac-m1-cross-compile"
+if [ "$ARCH" == "arm" ]; then
+    CROSS_COMPILE_PROFILE="mac-intel-cross-compile"
+fi
+
+git fetch
+git checkout "$2"
+
+export JAVA_HOME="$JAVA8_HOME"
+
+./mvnw -Psonatype-oss-release,"$CROSS_COMPILE_PROFILE" clean package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DstagingRepositoryId="$1" -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DskipTests=true
+./mvnw -Psonatype-oss-release clean package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DstagingRepositoryId="$1" -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DskipTests=true -DstagingProgressTimeoutMinutes=10
+./mvnw -Psonatype-oss-release org.sonatype.plugins:nexus-staging-maven-plugin:rc-close  org.sonatype.plugins:nexus-staging-maven-plugin:rc-release -DstagingRepositoryId="$1" -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DskipTests=true -DstagingProgressTimeoutMinutes=10
+git checkout "$BRANCH"

--- a/scripts/list_staged_release.sh
+++ b/scripts/list_staged_release.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+RC_LIST=$(mvn org.sonatype.plugins:nexus-staging-maven-plugin:rc-list -DserverId=sonatype-nexus-staging -DnexusUrl=https://oss.sonatype.org | grep -A 2 "\[INFO\] ID                   State    Description")
+STAGED=$(echo "$RC_LIST" | grep 'OPEN' | cut -f 2 -d ' ')
+echo "$STAGED"


### PR DESCRIPTION
Motivation:

While we already have a BouncyCastle based HPKE implementation that we can use we should also offer an implementation which is faster and so reduce the performance overhead.

Modifications:

Add native implementation based on BoringSSL.

Result:

Fixes https://github.com/netty/netty-incubator-codec-ohttp/issues/5