### PR TITLE
Rename Builder.setReceiverPublicKeyBytes(...) to Builder.setReceiverP…

### DIFF
--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpClientCodec.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpClientCodec.java
@@ -317,7 +317,7 @@ public final class OHttpClientCodec extends MessageToMessageCodec<HttpObject, Ht
                     .setOHttpCryptoProvider(provider)
                     .setConfiguration(parameters.version())
                     .setCiphersuite(requireNonNull(parameters.ciphersuite(), "ciphersuite"))
-                    .setReceiverPublicKeyBytes(requireNonNull(parameters.serverPublicKey(), "serverPublicKey"))
+                    .setReceiverPublicKey(requireNonNull(parameters.serverPublicKey(), "serverPublicKey"))
                     .build();
         }
 

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCryptoSender.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCryptoSender.java
@@ -40,7 +40,7 @@ public final class OHttpCryptoSender extends OHttpCrypto {
         private OHttpCryptoProvider provider;
         private OHttpCryptoConfiguration configuration;
         private OHttpCiphersuite ciphersuite;
-        private AsymmetricKeyParameter receiverPublicKeyBytes;
+        private AsymmetricKeyParameter receiverPublicKey;
         private AsymmetricCipherKeyPair forcedEphemeralKeyPair; // for testing only!
 
         public Builder setOHttpCryptoProvider(OHttpCryptoProvider provider) {
@@ -58,8 +58,8 @@ public final class OHttpCryptoSender extends OHttpCrypto {
             return this;
         }
 
-        public Builder setReceiverPublicKeyBytes(AsymmetricKeyParameter value) {
-            this.receiverPublicKeyBytes = value;
+        public Builder setReceiverPublicKey(AsymmetricKeyParameter value) {
+            this.receiverPublicKey = value;
             return this;
         }
 
@@ -90,7 +90,7 @@ public final class OHttpCryptoSender extends OHttpCrypto {
         this.ciphersuite = requireNonNull(builder.ciphersuite, "ciphersuite");
         this.provider = requireNonNull(builder.provider, "provider");
 
-        AsymmetricKeyParameter pkR = requireNonNull(builder.receiverPublicKeyBytes, "receiverPublicKeyBytes");
+        AsymmetricKeyParameter pkR = requireNonNull(builder.receiverPublicKey, "receiverPublicKey");
         AsymmetricCipherKeyPair forcedEphemeralKeyPair = builder.forcedEphemeralKeyPair;
         this.context = this.provider.setupHPKEBaseS(OHttpCryptoProvider.Mode.Base, ciphersuite.kem(),
                 ciphersuite.kdf(), ciphersuite.aead(), pkR, ciphersuite.createInfo(configuration),

--- a/codec-ohttp/src/test/java/io/netty/incubator/codec/ohttp/OHttpCryptoTest.java
+++ b/codec-ohttp/src/test/java/io/netty/incubator/codec/ohttp/OHttpCryptoTest.java
@@ -118,7 +118,7 @@ public class OHttpCryptoTest {
                 .setOHttpCryptoProvider(provider)
                 .setConfiguration(OHttpVersionDraft.INSTANCE)
                 .setCiphersuite(ciphersuite)
-                .setReceiverPublicKeyBytes(kpR.publicParameters())
+                .setReceiverPublicKey(kpR.publicParameters())
                 .setForcedEphemeralKeyPair(kpE)
                 .build()) {
 


### PR DESCRIPTION
…ublicKey(...)

Motivation:

Rename method as the naming is not accurate anymore.

Modifications:

Rename Builder.setReceiverPublicKeyBytes(...) to Builder.setReceiverPublicKey(...)

Result:

Better API naming