### PR TITLE
Reuse EVP_HPKE_KEY when using BoringSSLOHttpCryptoProvider.setupHPKEB…

### DIFF
--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAEADContext.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAEADContext.java
@@ -61,8 +61,8 @@ final class BoringSSLAEADContext extends BoringSSLCryptoContext implements AEADC
         }
     };
 
-    BoringSSLAEADContext(long ctx, int aeadMaxOverhead, byte[] baseNonce) {
-        super(ctx);
+    BoringSSLAEADContext(BoringSSLOHttpCryptoProvider cryptoProvider, long ctx, int aeadMaxOverhead, byte[] baseNonce) {
+        super(cryptoProvider, ctx);
         this.nonce = new Nonce(baseNonce);
         this.aeadMaxOverhead = aeadMaxOverhead;
     }

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAsymmetricCipherKeyPair.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAsymmetricCipherKeyPair.java
@@ -22,8 +22,11 @@ import io.netty.incubator.codec.hpke.AsymmetricKeyParameter;
 final class BoringSSLAsymmetricCipherKeyPair implements AsymmetricCipherKeyPair {
     private final BoringSSLAsymmetricKeyParameter privateKey;
     private final BoringSSLAsymmetricKeyParameter publicKey;
+    final long key;
 
-    BoringSSLAsymmetricCipherKeyPair(byte[] privateKeyBytes, byte[] publicKeyBytes) {
+    BoringSSLAsymmetricCipherKeyPair(long key, byte[] privateKeyBytes, byte[] publicKeyBytes) {
+        assert key != -1;
+        this.key = key;
         privateKey = new BoringSSLAsymmetricKeyParameter(privateKeyBytes, true);
         publicKey = new BoringSSLAsymmetricKeyParameter(publicKeyBytes, false);
     }

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLCryptoContext.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLCryptoContext.java
@@ -24,10 +24,13 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 abstract class BoringSSLCryptoContext implements CryptoContext {
 
+    private final BoringSSLOHttpCryptoProvider cryptoProvider;
+
     // We use an AtomicLong to reduce the possibility of crashing after the user called close().
     private final AtomicLong ctxRef;
 
-    BoringSSLCryptoContext(long ctx) {
+    BoringSSLCryptoContext(BoringSSLOHttpCryptoProvider cryptoProvider, long ctx) {
+        this.cryptoProvider = cryptoProvider;
         assert ctx != -1;
         this.ctxRef = new AtomicLong(ctx);
     }
@@ -51,6 +54,7 @@ abstract class BoringSSLCryptoContext implements CryptoContext {
        long ctx = ctxRef.getAndSet(-1);
        if (ctx != -1) {
            destroyCtx(ctx);
+           cryptoProvider.free_EVP_HPKE_KEYS();
        }
     }
 

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKEContext.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKEContext.java
@@ -22,8 +22,8 @@ import io.netty.incubator.codec.hpke.HPKEContext;
  */
 class BoringSSLHPKEContext extends BoringSSLCryptoContext implements HPKEContext {
 
-    BoringSSLHPKEContext(long hpkeCtx) {
-        super(hpkeCtx);
+    BoringSSLHPKEContext(BoringSSLOHttpCryptoProvider cryptoProvider, long hpkeCtx) {
+        super(cryptoProvider, hpkeCtx);
     }
 
     @Override

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKERecipientContext.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKERecipientContext.java
@@ -37,8 +37,8 @@ final class BoringSSLHPKERecipientContext extends BoringSSLHPKEContext implement
         }
     };
 
-    BoringSSLHPKERecipientContext(long hpkeCtx) {
-        super(hpkeCtx);
+    BoringSSLHPKERecipientContext(BoringSSLOHttpCryptoProvider cryptoProvider, long hpkeCtx) {
+        super(cryptoProvider, hpkeCtx);
     }
 
     @Override

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKERecipientContext.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKERecipientContext.java
@@ -17,6 +17,7 @@ package io.netty.incubator.codec.hpke.boringssl;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.incubator.codec.hpke.AsymmetricCipherKeyPair;
 import io.netty.incubator.codec.hpke.CryptoException;
 import io.netty.incubator.codec.hpke.HPKERecipientContext;
 
@@ -37,8 +38,13 @@ final class BoringSSLHPKERecipientContext extends BoringSSLHPKEContext implement
         }
     };
 
-    BoringSSLHPKERecipientContext(BoringSSLOHttpCryptoProvider cryptoProvider, long hpkeCtx) {
+    // Store a reference to the keyPair here so we are sure it will only be GCed once the context is collected as well.
+    final AsymmetricCipherKeyPair keyPair;
+
+    BoringSSLHPKERecipientContext(BoringSSLOHttpCryptoProvider cryptoProvider, long hpkeCtx,
+                                  AsymmetricCipherKeyPair keyPair) {
         super(cryptoProvider, hpkeCtx);
+        this.keyPair = keyPair;
     }
 
     @Override

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKESenderContext.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKESenderContext.java
@@ -41,8 +41,8 @@ final class BoringSSLHPKESenderContext extends BoringSSLHPKEContext
 
     private final byte[] encapsulation;
 
-    BoringSSLHPKESenderContext(long hpkeCtx, byte[] encapsulation) {
-        super(hpkeCtx);
+    BoringSSLHPKESenderContext(BoringSSLOHttpCryptoProvider cryptoProvider, long hpkeCtx, byte[] encapsulation) {
+        super(cryptoProvider, hpkeCtx);
         this.encapsulation = encapsulation;
     }
 

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLOHttpCryptoProvider.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLOHttpCryptoProvider.java
@@ -26,6 +26,8 @@ import io.netty.incubator.codec.hpke.KDF;
 import io.netty.incubator.codec.hpke.KEM;
 import io.netty.incubator.codec.hpke.OHttpCryptoProvider;
 
+import java.lang.ref.PhantomReference;
+import java.lang.ref.ReferenceQueue;
 import java.util.Arrays;
 
 /**
@@ -34,6 +36,16 @@ import java.util.Arrays;
  * the native library can be loaded on the used platform.
  */
 public final class BoringSSLOHttpCryptoProvider implements OHttpCryptoProvider {
+
+    private final ReferenceQueue<BoringSSLAsymmetricCipherKeyPair> keyPairRefQueue = new ReferenceQueue<>();
+    private static final class EVP_HPKE_KEY_PhantomRef extends PhantomReference<BoringSSLAsymmetricCipherKeyPair> {
+        private final long key;
+        EVP_HPKE_KEY_PhantomRef(BoringSSLAsymmetricCipherKeyPair referent,
+                                       ReferenceQueue<BoringSSLAsymmetricCipherKeyPair> q) {
+            super(referent, q);
+            this.key = referent.key;
+        }
+    }
 
     /**
      * {@link BoringSSLOHttpCryptoProvider} instance.
@@ -58,7 +70,7 @@ public final class BoringSSLOHttpCryptoProvider implements OHttpCryptoProvider {
         int maxOverhead = BoringSSL.EVP_AEAD_max_overhead(boringSSLAead);
         long ctx = BoringSSL.EVP_AEAD_CTX_new_or_throw(boringSSLAead, key, BoringSSL.EVP_AEAD_DEFAULT_TAG_LENGTH);
         try {
-            BoringSSLAEADContext aeadCtx = new BoringSSLAEADContext(ctx, maxOverhead, baseNonce);
+            BoringSSLAEADContext aeadCtx = new BoringSSLAEADContext(this, ctx, maxOverhead, baseNonce);
             ctx = -1;
             return aeadCtx;
         } finally {
@@ -132,7 +144,7 @@ public final class BoringSSLOHttpCryptoProvider implements OHttpCryptoProvider {
                 throw new IllegalStateException("Unable to setup EVP_HPKE_CTX");
             }
             BoringSSLHPKESenderContext hpkeCtx =
-                    new BoringSSLHPKESenderContext(ctx, encapsulation);
+                    new BoringSSLHPKESenderContext(this, ctx, encapsulation);
             ctx = -1;
             return hpkeCtx;
         } finally {
@@ -160,19 +172,28 @@ public final class BoringSSLOHttpCryptoProvider implements OHttpCryptoProvider {
 
         long ctx = -1;
         long key = -1;
+        boolean freeKey = true;
         try {
-            byte[] privateKeyBytes = encodedAsymmetricKeyParameter(skR.privateParameters());
-            key = BoringSSL.EVP_HPKE_KEY_new_and_init_or_throw(boringSSLKem, privateKeyBytes);
+            if (skR instanceof BoringSSLAsymmetricCipherKeyPair) {
+                key = ((BoringSSLAsymmetricCipherKeyPair) skR).key;
+                freeKey = false;
+            } else {
+                byte[] privateKeyBytes = encodedAsymmetricKeyParameter(skR.privateParameters());
+                key = BoringSSL.EVP_HPKE_KEY_new_and_init_or_throw(boringSSLKem, privateKeyBytes);
+            }
+
             ctx = BoringSSL.EVP_HPKE_CTX_new_or_throw();
             if (BoringSSL.EVP_HPKE_CTX_setup_recipient(ctx, key, boringSSLKdf, boringSSLAead, enc, info) != 1) {
                 throw new IllegalStateException("Unable to setup EVP_HPKE_CTX");
             }
 
-            BoringSSLHPKERecipientContext hpkeCtx = new BoringSSLHPKERecipientContext(ctx);
+            BoringSSLHPKERecipientContext hpkeCtx = new BoringSSLHPKERecipientContext(this, ctx);
             ctx = -1;
             return hpkeCtx;
         } finally {
-            BoringSSL.EVP_HPKE_KEY_cleanup_and_free(key);
+            if (freeKey && key != -1) {
+                BoringSSL.EVP_HPKE_KEY_cleanup_and_free(key);
+            }
             if (ctx != -1) {
                 BoringSSL.EVP_HPKE_CTX_cleanup_and_free(ctx);
             }
@@ -193,9 +214,15 @@ public final class BoringSSLOHttpCryptoProvider implements OHttpCryptoProvider {
                         "publicKeyBytes does not contain a valid public key: " + Arrays.toString(publicKeyBytes));
             }
             // No need to clone extractedPublicKey as it was returned by our native call.
-            return new BoringSSLAsymmetricCipherKeyPair(privateKeyBytes.clone(), extractedPublicKey);
+            BoringSSLAsymmetricCipherKeyPair pair =
+                    new BoringSSLAsymmetricCipherKeyPair(key, privateKeyBytes.clone(), extractedPublicKey);
+            new EVP_HPKE_KEY_PhantomRef(pair, keyPairRefQueue);
+            key = -1;
+            return pair;
         } finally {
-            BoringSSL.EVP_HPKE_KEY_cleanup_and_free(key);
+            if (key != -1) {
+                BoringSSL.EVP_HPKE_KEY_cleanup_and_free(key);
+            }
         }
     }
 
@@ -223,7 +250,10 @@ public final class BoringSSLOHttpCryptoProvider implements OHttpCryptoProvider {
             if (privateKeyBytes == null || publicKeyBytes == null) {
                 throw new IllegalStateException("Unable to generate random key");
             }
-            return new BoringSSLAsymmetricCipherKeyPair(privateKeyBytes, publicKeyBytes);
+            BoringSSLAsymmetricCipherKeyPair pair =
+                    new BoringSSLAsymmetricCipherKeyPair(key, privateKeyBytes, publicKeyBytes);
+            key = -1;
+            return pair;
         } finally {
             BoringSSL.EVP_HPKE_KEY_cleanup_and_free(key);
         }
@@ -252,6 +282,19 @@ public final class BoringSSLOHttpCryptoProvider implements OHttpCryptoProvider {
     @Override
     public boolean isSupported(KDF kdf) {
         return kdf == KDF.HKDF_SHA256;
+    }
+
+    /**
+     * Try to free enqueued {@code EVP_HPKE_KEY}s.
+     */
+    void free_EVP_HPKE_KEYS() {
+        for (;;) {
+            EVP_HPKE_KEY_PhantomRef ref = (EVP_HPKE_KEY_PhantomRef) keyPairRefQueue.poll();
+            if (ref == null) {
+                return;
+            }
+            BoringSSL.EVP_HPKE_KEY_cleanup_and_free(ref.key);
+        }
     }
 }
 

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLOHttpCryptoProvider.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLOHttpCryptoProvider.java
@@ -187,7 +187,9 @@ public final class BoringSSLOHttpCryptoProvider implements OHttpCryptoProvider {
                 throw new IllegalStateException("Unable to setup EVP_HPKE_CTX");
             }
 
-            BoringSSLHPKERecipientContext hpkeCtx = new BoringSSLHPKERecipientContext(this, ctx);
+            // Store a reference to the keyPair so we are sure it will only be GCed once the context is collected as
+            // well. This ensures the key is not added to the reference queue before the context is destroyed as well.
+            BoringSSLHPKERecipientContext hpkeCtx = new BoringSSLHPKERecipientContext(this, ctx, skR);
             ctx = -1;
             return hpkeCtx;
         } finally {


### PR DESCRIPTION
…aseR(...)

Motivation:

When we generate the BoringSSLAsymmetricCipherKeyPair we can also just store the EVP_HPE_KEY in the object and so use it directly when setupHPKEBaseR(...) is used. This will make things cheaper.

Modifications:

Store the pointer to EVP_HPE_KEY in BoringSSLAsymmetricCipherKeyPair and use a PhantomReference to free it later.

Result:

Less overhead