### PR TITLE
Correctly handle result value of native BoringSSL crypto operations

### DIFF
--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLCryptoOperation.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLCryptoOperation.java
@@ -53,7 +53,7 @@ abstract class BoringSSLCryptoOperation {
             int result = execute(ctx, directAadAddress, directAddReadableBytes,
                     directInAddress, directInReadableBytes,
                     directOutAddress, directOutWritableBytes);
-            if (result <= 0) {
+            if (result < 0) {
                 return false;
             }
             aad.skipBytes(directAddReadableBytes);


### PR DESCRIPTION
Motivation:

We should only handle -1 as failure as a return value of 0 is still valid in the sense that it just means there was nothing written to the output buffer.

Modifications:

Only handle return value of -1 as failure

Result:

Correctly handle native return values