### PR TITLE
Move enums out of OHttpCryptoProvider

### DIFF
--- a/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleOHttpCryptoProvider.java
+++ b/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleOHttpCryptoProvider.java
@@ -15,11 +15,15 @@
  */
 package io.netty.incubator.codec.hpke.bouncycastle;
 
+import io.netty.incubator.codec.hpke.AEAD;
 import io.netty.incubator.codec.hpke.AEADContext;
 import io.netty.incubator.codec.hpke.AsymmetricCipherKeyPair;
 import io.netty.incubator.codec.hpke.AsymmetricKeyParameter;
+import io.netty.incubator.codec.hpke.HPKEMode;
 import io.netty.incubator.codec.hpke.HPKERecipientContext;
 import io.netty.incubator.codec.hpke.HPKESenderContext;
+import io.netty.incubator.codec.hpke.KDF;
+import io.netty.incubator.codec.hpke.KEM;
 import io.netty.incubator.codec.hpke.OHttpCryptoProvider;
 import org.bouncycastle.crypto.params.ECDomainParameters;
 import org.bouncycastle.crypto.params.ECPrivateKeyParameters;
@@ -42,7 +46,7 @@ import java.util.List;
 public final class BouncyCastleOHttpCryptoProvider implements OHttpCryptoProvider {
 
     private static final List<AEAD> SUPPORTED_AEAD_LIST = Collections.unmodifiableList(Arrays.asList(AEAD.values()));
-    private static final List<Mode> SUPPORTED_MODE_LIST = Collections.unmodifiableList(Arrays.asList(Mode.values()));
+    private static final List<HPKEMode> SUPPORTED_MODE_LIST = Collections.unmodifiableList(Arrays.asList(HPKEMode.values()));
     private static final List<KEM> SUPPORTED_KEM_LIST = Collections.unmodifiableList(Arrays.asList(KEM.values()));
     private static final List<KDF> SUPPORTED_KDF_LIST = Collections.unmodifiableList(Arrays.asList(KDF.values()));
 
@@ -70,9 +74,9 @@ public final class BouncyCastleOHttpCryptoProvider implements OHttpCryptoProvide
     }
 
     @Override
-    public HPKESenderContext setupHPKEBaseS(Mode mode, KEM kem, KDF kdf, AEAD aead,
-                                                       AsymmetricKeyParameter pkR, byte[] info,
-                                                       AsymmetricCipherKeyPair kpE) {
+    public HPKESenderContext setupHPKEBaseS(HPKEMode mode, KEM kem, KDF kdf, AEAD aead,
+                                            AsymmetricKeyParameter pkR, byte[] info,
+                                            AsymmetricCipherKeyPair kpE) {
         org.bouncycastle.crypto.hpke.HPKE hpke =
                 new org.bouncycastle.crypto.hpke.HPKE(mode.value(), kem.id(), kdf.id(), aead.id());
         final org.bouncycastle.crypto.hpke.HPKEContextWithEncapsulation ctx;
@@ -85,7 +89,7 @@ public final class BouncyCastleOHttpCryptoProvider implements OHttpCryptoProvide
     }
 
     @Override
-    public HPKERecipientContext setupHPKEBaseR(Mode mode, KEM kem, KDF kdf, AEAD aead, byte[] enc,
+    public HPKERecipientContext setupHPKEBaseR(HPKEMode mode, KEM kem, KDF kdf, AEAD aead, byte[] enc,
                                                AsymmetricCipherKeyPair skR, byte[] info) {
         org.bouncycastle.crypto.hpke.HPKE hpke =
                 new org.bouncycastle.crypto.hpke.HPKE(mode.value(), kem.id(), kdf.id(), aead.id());
@@ -205,7 +209,7 @@ public final class BouncyCastleOHttpCryptoProvider implements OHttpCryptoProvide
     }
 
     @Override
-    public List<Mode> supportedMode() {
+    public List<HPKEMode> supportedMode() {
         return SUPPORTED_MODE_LIST;
     }
 }

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLOHttpCryptoProvider.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLOHttpCryptoProvider.java
@@ -16,11 +16,15 @@
 package io.netty.incubator.codec.hpke.boringssl;
 
 
+import io.netty.incubator.codec.hpke.AEAD;
 import io.netty.incubator.codec.hpke.AEADContext;
 import io.netty.incubator.codec.hpke.AsymmetricCipherKeyPair;
 import io.netty.incubator.codec.hpke.AsymmetricKeyParameter;
+import io.netty.incubator.codec.hpke.HPKEMode;
 import io.netty.incubator.codec.hpke.HPKERecipientContext;
 import io.netty.incubator.codec.hpke.HPKESenderContext;
+import io.netty.incubator.codec.hpke.KDF;
+import io.netty.incubator.codec.hpke.KEM;
 import io.netty.incubator.codec.hpke.OHttpCryptoProvider;
 
 import java.util.Arrays;
@@ -35,7 +39,7 @@ import java.util.List;
 public final class BoringSSLOHttpCryptoProvider implements OHttpCryptoProvider {
 
     private static final List<AEAD> SUPPORTED_AEAD_LIST = Collections.unmodifiableList(Arrays.asList(AEAD.values()));
-    private static final List<Mode> SUPPORTED_MODE_LIST = Collections.singletonList(Mode.Base);
+    private static final List<HPKEMode> SUPPORTED_MODE_LIST = Collections.singletonList(HPKEMode.Base);
     private static final List<KEM> SUPPORTED_KEM_LIST = Collections.singletonList(KEM.X25519_SHA256);
     private static final List<KDF> SUPPORTED_KDF_LIST = Collections.singletonList(KDF.HKDF_SHA256);
 
@@ -111,16 +115,16 @@ public final class BoringSSLOHttpCryptoProvider implements OHttpCryptoProvider {
         }
     }
 
-    private static void validateMode(Mode mode) {
+    private static void validateMode(HPKEMode mode) {
         // TODO: Also support AUTH
-        if (mode != Mode.Base) {
+        if (mode != HPKEMode.Base) {
             throw new IllegalArgumentException("Mode not supported: " + mode);
         }
     }
 
     @Override
     public HPKESenderContext setupHPKEBaseS(
-            Mode mode, KEM kem, KDF kdf, AEAD aead, AsymmetricKeyParameter pkR,
+            HPKEMode mode, KEM kem, KDF kdf, AEAD aead, AsymmetricKeyParameter pkR,
             byte[] info, AsymmetricCipherKeyPair kpE) {
         validateMode(mode);
         long boringSSLKem = boringSSLKEM(kem);
@@ -163,7 +167,7 @@ public final class BoringSSLOHttpCryptoProvider implements OHttpCryptoProvider {
     }
 
     @Override
-    public HPKERecipientContext setupHPKEBaseR(Mode mode, KEM kem, KDF kdf, AEAD aead, byte[] enc,
+    public HPKERecipientContext setupHPKEBaseR(HPKEMode mode, KEM kem, KDF kdf, AEAD aead, byte[] enc,
                                                AsymmetricCipherKeyPair skR, byte[] info) {
         validateMode(mode);
         // Validate that KEM is supported by BoringSSL
@@ -240,7 +244,7 @@ public final class BoringSSLOHttpCryptoProvider implements OHttpCryptoProvider {
     }
 
     @Override
-    public List<Mode> supportedMode() {
+    public List<HPKEMode> supportedMode() {
         return SUPPORTED_MODE_LIST;
     }
 }

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/AEAD.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/AEAD.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.hpke;
+
+/**
+ * <a href="https://www.rfc-editor.org/rfc/rfc9180.html#name-authenticated-encryption-wi">Authenticated Encryption with Associated Data (AEAD) Functions</a>
+ */
+public enum AEAD {
+    AES_GCM128((short) 0x0001, 16, 12),
+    AES_GCM256((short) 0x0002, 32, 12),
+    CHACHA20_POLY1305((short) 0x0003, 32, 12);
+
+    public static AEAD forId(short id) {
+        for (AEAD val : values()) {
+            if (val.id == id) {
+                return val;
+            }
+        }
+        throw new IllegalArgumentException("unknown AEAD id " + id);
+    }
+
+    private final short id;
+    private final int nk;
+    private final int nn;
+
+    AEAD(short id, int nk, int nn) {
+        this.id = id;
+        this.nk = nk;
+        this.nn = nn;
+    }
+
+    public short id() {
+        return id;
+    }
+
+    public int nk() {
+        return nk;
+    }
+
+    public int nn() {
+        return nn;
+    }
+}

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/HPKEMode.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/HPKEMode.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.hpke;
+
+/**
+ * <a href="https://www.rfc-editor.org/rfc/rfc9180.html#name-hybrid-public-key-encryptio">Hybrid Public Key Encryption</a>
+ */
+public enum HPKEMode {
+    Base((byte) 0x00),
+    Psk((byte) 0x01),
+    Auth((byte) 0x02),
+    AuthPsk((byte) 0x03);
+
+    private final byte id;
+
+    HPKEMode(byte id) {
+        this.id = id;
+    }
+
+    public byte value() {
+        return id;
+    }
+
+    public static HPKEMode forId(byte id) {
+        for (HPKEMode val : values()) {
+            if (val.id == id) {
+                return val;
+            }
+        }
+        throw new IllegalArgumentException("unknown Mode id " + id);
+    }
+}

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/KDF.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/KDF.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.hpke;
+
+/**
+ * <a href="https://www.rfc-editor.org/rfc/rfc9180.html#name-key-derivation-functions-kd">Key Derivation Functions (KDFs)</a>
+ */
+public enum KDF {
+    HKDF_SHA256((short) 0x0001),
+    HKDF_SHA384((short) 0x0002),
+    HKDF_SHA512((short) 0x0003);
+
+    public static KDF forId(short id) {
+        for (KDF val : values()) {
+            if (val.id == id) {
+                return val;
+            }
+        }
+        throw new IllegalArgumentException("unknown KDF id " + id);
+    }
+
+    private final short id;
+
+    KDF(short id) {
+        this.id = id;
+    }
+
+    public short id() {
+        return id;
+    }
+}

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/KEM.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/KEM.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.hpke;
+
+/**
+ * <a href="https://www.rfc-editor.org/rfc/rfc9180.html#section-7.1">Key Encapsulation Mechanism</a>
+ */
+public enum KEM {
+    P256_SHA256((short) 16, 65, 65),
+    P384_SHA348((short) 17, 97, 97),
+    P521_SHA512((short) 18, 133, 133),
+    X25519_SHA256((short) 32, 32, 32),
+    X448_SHA512((short) 33, 56, 56);
+
+    public static KEM forId(short id) {
+        for (KEM val : values()) {
+            if (val.id == id) {
+                return val;
+            }
+        }
+        throw new IllegalArgumentException("unknown KEM id " + id);
+    }
+
+    KEM(short id, int nenc, int npk) {
+        this.id = id;
+        this.nenc = nenc;
+        this.npk = npk;
+    }
+
+    private final short id;
+    private final int nenc;
+    private final int npk;
+
+    public short id() {
+        return id;
+    }
+
+    public int nenc() {
+        return nenc;
+    }
+
+    public int npk() {
+        return npk;
+    }
+}

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/OHttpCryptoProvider.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/OHttpCryptoProvider.java
@@ -36,7 +36,7 @@ public interface OHttpCryptoProvider {
     /**
      * Establish a {@link HPKESenderContext} that can be used for encryption.
      *
-     * @param mode  the {@link Mode} to use.
+     * @param mode  the {@link HPKEMode} to use.
      * @param kem   the {@link KEM} to use.
      * @param kdf   the {@link KDF} to use.
      * @param aead  the {@link AEAD} to use.
@@ -45,13 +45,13 @@ public interface OHttpCryptoProvider {
      * @param kpE   the ephemeral keypair or {@code null} if none should be used.
      * @return      the context.
      */
-    HPKESenderContext setupHPKEBaseS(Mode mode, KEM kem, KDF kdf, AEAD aead,
-                                                AsymmetricKeyParameter pkR, byte[] info, AsymmetricCipherKeyPair kpE);
+    HPKESenderContext setupHPKEBaseS(HPKEMode mode, KEM kem, KDF kdf, AEAD aead,
+                                     AsymmetricKeyParameter pkR, byte[] info, AsymmetricCipherKeyPair kpE);
 
     /**
      * Establish a {@link HPKERecipientContext} that can be used for decryption.
      *
-     * @param mode  the {@link Mode} to use.
+     * @param mode  the {@link HPKEMode} to use.
      * @param kem   the {@link KEM} to use.
      * @param kdf   the {@link KDF} to use.
      * @param aead  the {@link AEAD} to use.
@@ -60,8 +60,8 @@ public interface OHttpCryptoProvider {
      * @param info  info parameter.
      * @return      the context.
      */
-    HPKERecipientContext setupHPKEBaseR(Mode mode, KEM kem, KDF kdf, AEAD aead, byte[] enc,
-                               AsymmetricCipherKeyPair skR, byte[] info);
+    HPKERecipientContext setupHPKEBaseR(HPKEMode mode, KEM kem, KDF kdf, AEAD aead, byte[] enc,
+                                        AsymmetricCipherKeyPair skR, byte[] info);
 
     /**
      * Deserialize the input and return the private key.
@@ -104,146 +104,9 @@ public interface OHttpCryptoProvider {
     List<KDF> supportedKDF();
 
     /**
-     * Returns an immutable {@link List} of all supported {@link Mode}s.
+     * Returns an immutable {@link List} of all supported {@link HPKEMode}s.
      *
-     * @return supported {@link Mode}s.
+     * @return supported {@link HPKEMode}s.
      */
-    List<Mode> supportedMode();
-
-    /**
-     * <a href="https://www.rfc-editor.org/rfc/rfc9180.html#name-hybrid-public-key-encryptio">Hybrid Public Key Encryption</a>
-     */
-    enum Mode {
-        Base((byte) 0x00),
-        Psk((byte) 0x01),
-        Auth((byte) 0x02),
-        AuthPsk((byte) 0x03);
-
-        private final byte id;
-
-        Mode(byte id) {
-            this.id = id;
-        }
-
-        public byte value() {
-            return id;
-        }
-
-        public static Mode forId(byte id) {
-            for (Mode val : values()) {
-                if (val.id == id) {
-                    return val;
-                }
-            }
-            throw new IllegalArgumentException("unknown Mode id " + id);
-        }
-    }
-
-    /**
-     * <a href="https://www.rfc-editor.org/rfc/rfc9180.html#section-7.1">Key Encapsulation Mechanism</a>
-     */
-    enum KEM {
-        P256_SHA256((short) 16, 65, 65),
-        P384_SHA348((short) 17, 97, 97),
-        P521_SHA512((short) 18, 133, 133),
-        X25519_SHA256((short) 32, 32, 32),
-        X448_SHA512((short) 33, 56, 56);
-
-        public static KEM forId(short id) {
-            for (KEM val : values()) {
-                if (val.id == id) {
-                    return val;
-                }
-            }
-            throw new IllegalArgumentException("unknown KEM id " + id);
-        }
-
-        KEM(short id, int nenc, int npk) {
-            this.id = id;
-            this.nenc = nenc;
-            this.npk = npk;
-        }
-
-        private final short id;
-        private final int nenc;
-        private final int npk;
-
-        public short id() {
-            return id;
-        }
-
-        public int nenc() {
-            return nenc;
-        }
-
-        public int npk() {
-            return npk;
-        }
-    }
-
-    /**
-     * <a href="https://www.rfc-editor.org/rfc/rfc9180.html#name-key-derivation-functions-kd">Key Derivation Functions (KDFs)</a>
-     */
-    enum KDF {
-        HKDF_SHA256((short) 0x0001),
-        HKDF_SHA384((short) 0x0002),
-        HKDF_SHA512((short) 0x0003);
-
-        public static KDF forId(short id) {
-            for (KDF val : values()) {
-                if (val.id == id) {
-                    return val;
-                }
-            }
-            throw new IllegalArgumentException("unknown KDF id " + id);
-        }
-
-        private final short id;
-        KDF(short id) {
-            this.id = id;
-        }
-
-        public short id() {
-            return id;
-        }
-    }
-
-    /**
-     * <a href="https://www.rfc-editor.org/rfc/rfc9180.html#name-authenticated-encryption-wi">Authenticated Encryption with Associated Data (AEAD) Functions</a>
-     */
-    enum AEAD {
-        AES_GCM128((short) 0x0001, 16, 12),
-        AES_GCM256((short) 0x0002, 32, 12),
-        CHACHA20_POLY1305((short) 0x0003, 32, 12);
-
-        public static AEAD forId(short id) {
-            for (AEAD val : values()) {
-                if (val.id == id) {
-                    return val;
-                }
-            }
-            throw new IllegalArgumentException("unknown AEAD id " + id);
-        }
-
-        private final short id;
-        private final int nk;
-        private final int nn;
-        AEAD(short id, int nk, int nn) {
-            this.id = id;
-            this.nk = nk;
-            this.nn = nn;
-        }
-
-        public short id() {
-            return id;
-        }
-
-        public int nk() {
-            return nk;
-        }
-
-        public int nn() {
-            return nn;
-        }
-    }
+    List<HPKEMode> supportedMode();
 }

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCiphersuite.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCiphersuite.java
@@ -15,9 +15,11 @@
  */
 package io.netty.incubator.codec.ohttp;
 
+import io.netty.incubator.codec.hpke.AEAD;
 import io.netty.incubator.codec.hpke.AEADContext;
-import io.netty.incubator.codec.hpke.CryptoContext;
 import io.netty.incubator.codec.hpke.HPKEContext;
+import io.netty.incubator.codec.hpke.KDF;
+import io.netty.incubator.codec.hpke.KEM;
 import io.netty.incubator.codec.hpke.OHttpCryptoProvider;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -35,8 +37,8 @@ public final class OHttpCiphersuite {
 
     private static final int ENCODED_LENGTH = 7;
 
-    public OHttpCiphersuite(byte keyId, OHttpCryptoProvider.KEM kem, OHttpCryptoProvider.KDF kdf,
-                            OHttpCryptoProvider.AEAD aead) {
+    public OHttpCiphersuite(byte keyId, KEM kem, KDF kdf,
+                            AEAD aead) {
         this.keyId = keyId;
         this.kem = requireNonNull(kem, "kem");
         this.kdf = requireNonNull(kdf, "kdf");
@@ -44,9 +46,9 @@ public final class OHttpCiphersuite {
     }
 
     private final byte keyId;
-    private final OHttpCryptoProvider.KEM kem;
-    private final OHttpCryptoProvider.KDF kdf;
-    private final OHttpCryptoProvider.AEAD aead;
+    private final KEM kem;
+    private final KDF kdf;
+    private final AEAD aead;
 
     public int responseNonceLength() {
         return Math.max(aead.nk(), aead.nn());
@@ -61,15 +63,15 @@ public final class OHttpCiphersuite {
         return keyId;
     }
 
-    public OHttpCryptoProvider.KEM kem() {
+    public KEM kem() {
         return kem;
     }
 
-    public OHttpCryptoProvider.KDF kdf() {
+    public KDF kdf() {
         return kdf;
     }
 
-    public OHttpCryptoProvider.AEAD aead() {
+    public AEAD aead() {
         return aead;
     }
 
@@ -109,9 +111,9 @@ public final class OHttpCiphersuite {
             short aeadId = in.readShort();
             return new OHttpCiphersuite(
                     keyId,
-                    OHttpCryptoProvider.KEM.forId(kemId),
-                    OHttpCryptoProvider.KDF.forId(kdfId),
-                    OHttpCryptoProvider.AEAD.forId(aeadId));
+                    KEM.forId(kemId),
+                    KDF.forId(kdfId),
+                    AEAD.forId(aeadId));
         } catch (Exception e) {
             throw new DecoderException("invalid ciphersuite", e);
         }

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCryptoReceiver.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCryptoReceiver.java
@@ -16,12 +16,11 @@
 package io.netty.incubator.codec.ohttp;
 
 import io.netty.incubator.codec.hpke.AsymmetricCipherKeyPair;
-import io.netty.incubator.codec.hpke.CryptoContext;
 import io.netty.incubator.codec.hpke.CryptoDecryptContext;
 import io.netty.incubator.codec.hpke.CryptoEncryptContext;
-import io.netty.incubator.codec.hpke.HPKEContext;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.DecoderException;
+import io.netty.incubator.codec.hpke.HPKEMode;
 import io.netty.incubator.codec.hpke.HPKERecipientContext;
 import io.netty.incubator.codec.hpke.OHttpCryptoProvider;
 
@@ -102,7 +101,7 @@ public final class OHttpCryptoReceiver extends OHttpCrypto {
         if (keyPair == null) {
             throw new DecoderException("ciphersuite not supported");
         }
-        this.context = provider.setupHPKEBaseR(OHttpCryptoProvider.Mode.Base, ciphersuite.kem(), ciphersuite.kdf(),
+        this.context = provider.setupHPKEBaseR(HPKEMode.Base, ciphersuite.kem(), ciphersuite.kdf(),
                 ciphersuite.aead(), encapsulatedKey, keyPair, ciphersuite.createInfo(configuration));
         if (builder.forcedResponseNonce == null) {
             this.responseNonce = builder.ciphersuite.createResponseNonce();

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCryptoSender.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCryptoSender.java
@@ -20,6 +20,7 @@ import io.netty.incubator.codec.hpke.AsymmetricKeyParameter;
 import io.netty.incubator.codec.hpke.CryptoDecryptContext;
 import io.netty.incubator.codec.hpke.CryptoEncryptContext;
 import io.netty.buffer.ByteBuf;
+import io.netty.incubator.codec.hpke.HPKEMode;
 import io.netty.incubator.codec.hpke.HPKESenderContext;
 import io.netty.incubator.codec.hpke.OHttpCryptoProvider;
 
@@ -92,7 +93,7 @@ public final class OHttpCryptoSender extends OHttpCrypto {
 
         AsymmetricKeyParameter pkR = requireNonNull(builder.receiverPublicKey, "receiverPublicKey");
         AsymmetricCipherKeyPair forcedEphemeralKeyPair = builder.forcedEphemeralKeyPair;
-        this.context = this.provider.setupHPKEBaseS(OHttpCryptoProvider.Mode.Base, ciphersuite.kem(),
+        this.context = this.provider.setupHPKEBaseS(HPKEMode.Base, ciphersuite.kem(),
                 ciphersuite.kdf(), ciphersuite.aead(), pkR, ciphersuite.createInfo(configuration),
                 forcedEphemeralKeyPair);
     }

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpKey.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpKey.java
@@ -17,14 +17,14 @@ package io.netty.incubator.codec.ohttp;
 
 import io.netty.incubator.codec.hpke.AsymmetricCipherKeyPair;
 import io.netty.incubator.codec.hpke.CryptoException;
-import io.netty.incubator.codec.hpke.OHttpCryptoProvider.AEAD;
-import io.netty.incubator.codec.hpke.OHttpCryptoProvider.KDF;
+import io.netty.incubator.codec.hpke.AEAD;
+import io.netty.incubator.codec.hpke.KDF;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static io.netty.incubator.codec.hpke.OHttpCryptoProvider.KEM;
+import io.netty.incubator.codec.hpke.KEM;
 import static java.util.Objects.requireNonNull;
 
 public abstract class OHttpKey {

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerKeys.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerKeys.java
@@ -25,7 +25,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import static io.netty.incubator.codec.hpke.OHttpCryptoProvider.KEM;
+import io.netty.incubator.codec.hpke.KEM;
 
 /**
  * Set of key pairs and cipher suites for a OHTTP server.

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerPublicKeys.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerPublicKeys.java
@@ -28,9 +28,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static io.netty.incubator.codec.hpke.OHttpCryptoProvider.AEAD;
-import static io.netty.incubator.codec.hpke.OHttpCryptoProvider.KDF;
-import static io.netty.incubator.codec.hpke.OHttpCryptoProvider.KEM;
+import io.netty.incubator.codec.hpke.AEAD;
+
+import io.netty.incubator.codec.hpke.KDF;
+
+import io.netty.incubator.codec.hpke.KEM;
 import static java.util.Objects.requireNonNull;
 
 /**

--- a/codec-ohttp/src/test/java/io/netty/incubator/codec/ohttp/OHttpCodecsTest.java
+++ b/codec-ohttp/src/test/java/io/netty/incubator/codec/ohttp/OHttpCodecsTest.java
@@ -21,8 +21,11 @@ import io.netty.incubator.codec.bhttp.DefaultBinaryHttpResponse;
 import io.netty.incubator.codec.bhttp.DefaultFullBinaryHttpRequest;
 import io.netty.incubator.codec.bhttp.DefaultFullBinaryHttpResponse;
 import io.netty.incubator.codec.bhttp.FullBinaryHttpRequest;
+import io.netty.incubator.codec.hpke.AEAD;
 import io.netty.incubator.codec.hpke.AsymmetricCipherKeyPair;
 import io.netty.incubator.codec.hpke.AsymmetricKeyParameter;
+import io.netty.incubator.codec.hpke.KDF;
+import io.netty.incubator.codec.hpke.KEM;
 import io.netty.incubator.codec.hpke.OHttpCryptoProvider;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -117,18 +120,18 @@ public class OHttpCodecsTest {
         OHttpServerKeys serverKeys = new OHttpServerKeys(
                 OHttpKey.newPrivateKey(
                         keyId,
-                        OHttpCryptoProvider.KEM.X25519_SHA256,
+                        KEM.X25519_SHA256,
                         Arrays.asList(
-                                OHttpKey.newCipher(OHttpCryptoProvider.KDF.HKDF_SHA256, OHttpCryptoProvider.AEAD.AES_GCM128),
-                                OHttpKey.newCipher(OHttpCryptoProvider.KDF.HKDF_SHA256, OHttpCryptoProvider.AEAD.CHACHA20_POLY1305)),
+                                OHttpKey.newCipher(KDF.HKDF_SHA256, AEAD.AES_GCM128),
+                                OHttpKey.newCipher(KDF.HKDF_SHA256, AEAD.CHACHA20_POLY1305)),
                         kpR));
 
         OHttpCiphersuite ciphersuite = new OHttpCiphersuite(keyId,
-                OHttpCryptoProvider.KEM.X25519_SHA256,
-                OHttpCryptoProvider.KDF.HKDF_SHA256,
-                OHttpCryptoProvider.AEAD.AES_GCM128);
+                KEM.X25519_SHA256,
+                KDF.HKDF_SHA256,
+                AEAD.AES_GCM128);
 
-        AsymmetricKeyParameter publicKey = clientProvider.deserializePublicKey(OHttpCryptoProvider.KEM.X25519_SHA256, kpR.publicParameters().encoded());
+        AsymmetricKeyParameter publicKey = clientProvider.deserializePublicKey(KEM.X25519_SHA256, kpR.publicParameters().encoded());
         return new ChannelPair() {
             @Override
             public EmbeddedChannel client() {

--- a/codec-ohttp/src/test/java/io/netty/incubator/codec/ohttp/OHttpCryptoTest.java
+++ b/codec-ohttp/src/test/java/io/netty/incubator/codec/ohttp/OHttpCryptoTest.java
@@ -39,9 +39,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static io.netty.incubator.codec.hpke.OHttpCryptoProvider.AEAD;
-import static io.netty.incubator.codec.hpke.OHttpCryptoProvider.KDF;
-import static io.netty.incubator.codec.hpke.OHttpCryptoProvider.KEM;
+import io.netty.incubator.codec.hpke.AEAD;
+
+import io.netty.incubator.codec.hpke.KDF;
+
+import io.netty.incubator.codec.hpke.KEM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 


### PR DESCRIPTION
Motivation:

It makes the code cleaner when we move the used enums out of OHttpCryptoProvider

Modifications:

Move enums out of OHttpCryptoProvider and rename Mode to HPKEMode

Result:

Cleanup