### PR TITLE
Replace OHttpCryptoProvider.supported* methods with isSupported(...) …

### DIFF
--- a/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleOHttpCryptoProvider.java
+++ b/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleOHttpCryptoProvider.java
@@ -39,17 +39,8 @@ import org.bouncycastle.math.ec.custom.sec.SecP521R1Curve;
 import org.bouncycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 public final class BouncyCastleOHttpCryptoProvider implements OHttpCryptoProvider {
-
-    private static final List<AEAD> SUPPORTED_AEAD_LIST = Collections.unmodifiableList(Arrays.asList(AEAD.values()));
-    private static final List<HPKEMode> SUPPORTED_MODE_LIST = Collections.unmodifiableList(Arrays.asList(HPKEMode.values()));
-    private static final List<KEM> SUPPORTED_KEM_LIST = Collections.unmodifiableList(Arrays.asList(KEM.values()));
-    private static final List<KDF> SUPPORTED_KDF_LIST = Collections.unmodifiableList(Arrays.asList(KDF.values()));
-
     public static final BouncyCastleOHttpCryptoProvider INSTANCE = new BouncyCastleOHttpCryptoProvider();
 
     private BouncyCastleOHttpCryptoProvider() { }
@@ -194,22 +185,65 @@ public final class BouncyCastleOHttpCryptoProvider implements OHttpCryptoProvide
     }
 
     @Override
-    public List<AEAD> supportedAEAD() {
-        return SUPPORTED_AEAD_LIST;
+    public boolean isSupported(AEAD aead) {
+        if (aead == null) {
+            return false;
+        }
+        switch (aead) {
+            case AES_GCM128:
+            case AES_GCM256:
+            case CHACHA20_POLY1305:
+                return true;
+            default:
+                return false;
+        }
     }
 
     @Override
-    public List<KEM> supportedKEM() {
-        return SUPPORTED_KEM_LIST;
+    public boolean isSupported(KEM kem) {
+        if (kem == null) {
+            return false;
+        }
+        switch (kem) {
+            case X25519_SHA256:
+            case P256_SHA256:
+            case P384_SHA348:
+            case P521_SHA512:
+            case X448_SHA512:
+                return true;
+            default:
+                return false;
+        }
     }
 
     @Override
-    public List<KDF> supportedKDF() {
-        return SUPPORTED_KDF_LIST;
+    public boolean isSupported(KDF kdf) {
+        if (kdf == null) {
+            return false;
+        }
+        switch (kdf) {
+            case HKDF_SHA256:
+            case HKDF_SHA384:
+            case HKDF_SHA512:
+                return true;
+            default:
+                return false;
+        }
     }
 
     @Override
-    public List<HPKEMode> supportedMode() {
-        return SUPPORTED_MODE_LIST;
+    public boolean isSupported(HPKEMode mode) {
+        if (mode == null) {
+            return false;
+        }
+        switch (mode) {
+            case Psk:
+            case Base:
+            case Auth:
+            case AuthPsk:
+                return true;
+            default:
+                return false;
+        }
     }
 }

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLOHttpCryptoProvider.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLOHttpCryptoProvider.java
@@ -28,8 +28,6 @@ import io.netty.incubator.codec.hpke.KEM;
 import io.netty.incubator.codec.hpke.OHttpCryptoProvider;
 
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * BoringSSL based {@link OHttpCryptoProvider}. {@link BoringSSLHPKE#ensureAvailability()} or
@@ -38,17 +36,13 @@ import java.util.List;
  */
 public final class BoringSSLOHttpCryptoProvider implements OHttpCryptoProvider {
 
-    private static final List<AEAD> SUPPORTED_AEAD_LIST = Collections.unmodifiableList(Arrays.asList(AEAD.values()));
-    private static final List<HPKEMode> SUPPORTED_MODE_LIST = Collections.singletonList(HPKEMode.Base);
-    private static final List<KEM> SUPPORTED_KEM_LIST = Collections.singletonList(KEM.X25519_SHA256);
-    private static final List<KDF> SUPPORTED_KDF_LIST = Collections.singletonList(KDF.HKDF_SHA256);
-
     /**
      * {@link BoringSSLOHttpCryptoProvider} instance.
      */
     public static final BoringSSLOHttpCryptoProvider INSTANCE = new BoringSSLOHttpCryptoProvider();
 
-    private BoringSSLOHttpCryptoProvider() { }
+    private BoringSSLOHttpCryptoProvider() {
+    }
 
     @Override
     public AEADContext setupAEAD(AEAD aead, byte[] key, byte[] baseNonce) {
@@ -90,14 +84,14 @@ public final class BoringSSLOHttpCryptoProvider implements OHttpCryptoProvider {
 
     private static long boringSSLKDF(KDF kdf) {
         if (kdf != KDF.HKDF_SHA256) {
-            throw new IllegalArgumentException("KDF not supported: "+ kdf);
+            throw new IllegalArgumentException("KDF not supported: " + kdf);
         }
         return BoringSSL.EVP_hpke_hkdf_sha256;
     }
 
     private static long boringSSLKEM(KEM kem) {
         if (kem != KEM.X25519_SHA256) {
-            throw new IllegalArgumentException("KEM not supported: "+ kem);
+            throw new IllegalArgumentException("KEM not supported: " + kem);
         }
         return BoringSSL.EVP_hpke_x25519_hkdf_sha256;
     }
@@ -229,22 +223,33 @@ public final class BoringSSLOHttpCryptoProvider implements OHttpCryptoProvider {
     }
 
     @Override
-    public List<AEAD> supportedAEAD() {
-        return SUPPORTED_AEAD_LIST;
+    public boolean isSupported(AEAD aead) {
+        if (aead == null) {
+            return false;
+        }
+        switch (aead) {
+            case AES_GCM128:
+            case AES_GCM256:
+            case CHACHA20_POLY1305:
+                return true;
+            default:
+                return false;
+        }
     }
 
     @Override
-    public List<KEM> supportedKEM() {
-        return SUPPORTED_KEM_LIST;
+    public boolean isSupported(KEM kem) {
+        return kem == KEM.X25519_SHA256;
     }
 
     @Override
-    public List<KDF> supportedKDF() {
-        return SUPPORTED_KDF_LIST;
+    public boolean isSupported(KDF kdf) {
+        return kdf == KDF.HKDF_SHA256;
     }
 
     @Override
-    public List<HPKEMode> supportedMode() {
-        return SUPPORTED_MODE_LIST;
+    public boolean isSupported(HPKEMode mode) {
+        return mode == HPKEMode.Base;
     }
 }
+

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/OHttpCryptoProvider.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/OHttpCryptoProvider.java
@@ -15,8 +15,6 @@
  */
 package io.netty.incubator.codec.hpke;
 
-import java.util.List;
-
 /**
  * Provides methods to handle <a href="https://www.rfc-editor.org/rfc/rfc9180.html">Hybrid Public Key Encryption</a>
  * for oHTTP. Because of that the functionality is limited to what is needed for oHTTP.
@@ -83,30 +81,34 @@ public interface OHttpCryptoProvider {
     AsymmetricKeyParameter deserializePublicKey(KEM kem, byte[] publicKeyBytes);
 
     /**
-     * Returns an immutable {@link List} of all supported {@link AEAD}s.
+     * Returns {@code true} if the given {@link AEAD} is supported by the implementation, {@code false} otherwise.
      *
-     * @return supported {@link AEAD}s.
+     * @param aead  the {@link AEAD}.
+     * @return      if supported.
      */
-    List<AEAD> supportedAEAD();
+    boolean isSupported(AEAD aead);
 
     /**
-     * Returns an immutable {@link List} of all supported {@link KEM}s.
+     * Returns {@code true} if the given {@link KEM} is supported by the implementation, {@code false} otherwise.
      *
-     * @return supported {@link KEM}s.
+     * @param kem   the {@link KEM}.
+     * @return      if supported.
      */
-    List<KEM> supportedKEM();
+    boolean isSupported(KEM kem);
 
     /**
-     * Returns an immutable {@link List} of all supported {@link KDF}s.
+     * Returns {@code true} if the given {@link KDF} is supported by the implementation, {@code false} otherwise.
      *
-     * @return supported {@link KDF}s.
+     * @param kdf   the {@link KDF}.
+     * @return      if supported.
      */
-    List<KDF> supportedKDF();
+    boolean isSupported(KDF kdf);
 
     /**
-     * Returns an immutable {@link List} of all supported {@link HPKEMode}s.
+     * Returns {@code true} if the given {@link HPKEMode} is supported by the implementation, {@code false} otherwise.
      *
-     * @return supported {@link HPKEMode}s.
+     * @param mode  the {@link HPKEMode}.
+     * @return      if supported.
      */
-    List<HPKEMode> supportedMode();
+    boolean isSupported(HPKEMode mode);
 }


### PR DESCRIPTION
…methods

Motivation:

Having an easy way to check if an enum is supported or not is better in terms of API.

Modifications:

Replace OHttpCryptoProvider.supported* methods with isSupported(...) methods

Result:

API cleanup