### PR TITLE
Add OHttpCryptoProvider.newRandomPrivateKey(...)

### DIFF
--- a/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleOHttpCryptoProvider.java
+++ b/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleOHttpCryptoProvider.java
@@ -44,6 +44,8 @@ import java.security.SecureRandom;
 public final class BouncyCastleOHttpCryptoProvider implements OHttpCryptoProvider {
     public static final BouncyCastleOHttpCryptoProvider INSTANCE = new BouncyCastleOHttpCryptoProvider();
 
+    private final SecureRandom random = new SecureRandom();
+
     private BouncyCastleOHttpCryptoProvider() { }
 
     @Override
@@ -187,17 +189,17 @@ public final class BouncyCastleOHttpCryptoProvider implements OHttpCryptoProvide
 
     @Override
     public AsymmetricCipherKeyPair newRandomPrivateKey(KEM kem) {
-        return new BouncyCastleAsymmetricCipherKeyPair(newRandomPair(kem));
+        return new BouncyCastleAsymmetricCipherKeyPair(newRandomPair(kem, random));
     }
 
-    private static org.bouncycastle.crypto.AsymmetricCipherKeyPair newRandomPair(KEM kem) {
+    private static org.bouncycastle.crypto.AsymmetricCipherKeyPair newRandomPair(KEM kem, SecureRandom random) {
         switch (kem) {
             case X25519_SHA256:
-                X25519PrivateKeyParameters x25519PrivateKey = new X25519PrivateKeyParameters(new SecureRandom());
+                X25519PrivateKeyParameters x25519PrivateKey = new X25519PrivateKeyParameters(random);
                 return new org.bouncycastle.crypto.AsymmetricCipherKeyPair(
                         x25519PrivateKey.generatePublicKey(), x25519PrivateKey);
             case X448_SHA512:
-                X448PrivateKeyParameters x448PrivateKey = new X448PrivateKeyParameters(new SecureRandom());
+                X448PrivateKeyParameters x448PrivateKey = new X448PrivateKeyParameters(random);
                 return new org.bouncycastle.crypto.AsymmetricCipherKeyPair(
                         x448PrivateKey.generatePublicKey(), x448PrivateKey);
             default:

--- a/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleOHttpCryptoProvider.java
+++ b/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleOHttpCryptoProvider.java
@@ -39,6 +39,7 @@ import org.bouncycastle.math.ec.custom.sec.SecP521R1Curve;
 import org.bouncycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
+import java.security.SecureRandom;
 
 public final class BouncyCastleOHttpCryptoProvider implements OHttpCryptoProvider {
     public static final BouncyCastleOHttpCryptoProvider INSTANCE = new BouncyCastleOHttpCryptoProvider();
@@ -181,6 +182,26 @@ public final class BouncyCastleOHttpCryptoProvider implements OHttpCryptoProvide
                 );
             default:
                 throw new IllegalArgumentException("invalid kem: " + kem);
+        }
+    }
+
+    @Override
+    public AsymmetricCipherKeyPair newRandomPrivateKey(KEM kem) {
+        return new BouncyCastleAsymmetricCipherKeyPair(newRandomPair(kem));
+    }
+
+    private static org.bouncycastle.crypto.AsymmetricCipherKeyPair newRandomPair(KEM kem) {
+        switch (kem) {
+            case X25519_SHA256:
+                X25519PrivateKeyParameters x25519PrivateKey = new X25519PrivateKeyParameters(new SecureRandom());
+                return new org.bouncycastle.crypto.AsymmetricCipherKeyPair(
+                        x25519PrivateKey.generatePublicKey(), x25519PrivateKey);
+            case X448_SHA512:
+                X448PrivateKeyParameters x448PrivateKey = new X448PrivateKeyParameters(new SecureRandom());
+                return new org.bouncycastle.crypto.AsymmetricCipherKeyPair(
+                        x448PrivateKey.generatePublicKey(), x448PrivateKey);
+            default:
+                throw new UnsupportedOperationException("Can't generate random key for kem: " + kem);
         }
     }
 

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSL.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSL.java
@@ -105,6 +105,8 @@ final class BoringSSL {
     static native int EVP_HPKE_CTX_max_overhead(long ctx);
 
     static native long EVP_HPKE_KEY_new();
+
+    static native int EVP_HPKE_KEY_generate(long key, long kem);
     static native void EVP_HPKE_KEY_free(long key);
     static native void EVP_HPKE_KEY_cleanup(long key);
 
@@ -182,6 +184,15 @@ final class BoringSSL {
             throw new IllegalArgumentException(
                     "privateKeyBytes does not contain a valid private key: " + Arrays.toString(privateKeyBytes));
         }
+    }
+
+    static long EVP_HPKE_KEY_new_and_generate_or_throw(long kem) {
+        long key = EVP_HPKE_KEY_new_or_throw();
+        if (EVP_HPKE_KEY_generate(key, kem) != 1) {
+            EVP_HPKE_KEY_cleanup_and_free(key);
+            throw new IllegalStateException("Unable to generate key for KEM: " + kem);
+        }
+        return key;
     }
 
     static void EVP_HPKE_KEY_cleanup_and_free(long key) {

--- a/codec-ohttp-hpke-native-boringssl/src/main/c/netty_incubator_codec_ohttp_hpke_boringssl.c
+++ b/codec-ohttp-hpke-native-boringssl/src/main/c/netty_incubator_codec_ohttp_hpke_boringssl.c
@@ -218,12 +218,16 @@ static jlong netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_new(JNIEnv*
     return (jlong) EVP_HPKE_KEY_new();
 }
 
+static void netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_free(JNIEnv* env, jclass clazz, jlong key) {
+    EVP_HPKE_KEY_free((EVP_HPKE_KEY *) key);
+}
+
 static void netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_cleanup(JNIEnv* env, jclass clazz, jlong key) {
     EVP_HPKE_KEY_cleanup((EVP_HPKE_KEY *) key);
 }
 
-static void netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_free(JNIEnv* env, jclass clazz, jlong key) {
-    EVP_HPKE_KEY_free((EVP_HPKE_KEY *) key);
+static jint netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_generate(JNIEnv* env, jclass clazz, jlong key, jlong kem) {
+    return (jint) EVP_HPKE_KEY_generate((EVP_HPKE_KEY *) key, (const EVP_HPKE_KEM *) kem);
 }
 
 static jint netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_init(JNIEnv* env, jclass clazz, jlong key, jlong kem, jbyteArray priv_key_array) {
@@ -394,6 +398,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "EVP_HPKE_KEY_new", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_new },
   { "EVP_HPKE_KEY_cleanup", "(J)V", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_cleanup },
   { "EVP_HPKE_KEY_free", "(J)V", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_free },
+  { "EVP_HPKE_KEY_generate", "(JJ)I", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_generate },
   { "EVP_HPKE_KEY_init", "(JJ[B)I", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_init },
   { "EVP_HPKE_KEY_public_key", "(J)[B", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_public_key },
   { "EVP_HPKE_KEY_private_key", "(J)[B", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_private_key },

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/OHttpCryptoProvider.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/OHttpCryptoProvider.java
@@ -80,6 +80,16 @@ public interface OHttpCryptoProvider {
      */
     AsymmetricKeyParameter deserializePublicKey(KEM kem, byte[] publicKeyBytes);
 
+
+    /**
+     * Generate a random private key. Please note that this might not be possible for all of the {@link KEM} and so
+     * this method might throw an {@link UnsupportedOperationException}.
+     *
+     * @param kem   the {@link KEM} that is used.
+     * @return      the generated key.
+     */
+    AsymmetricCipherKeyPair newRandomPrivateKey(KEM kem);
+
     /**
      * Returns {@code true} if the given {@link AEAD} is supported by the implementation, {@code false} otherwise.
      *


### PR DESCRIPTION
Motivation:

Sometimes its useful to generate a new random key, we should allow to do this via method on the OHttpCryptoProvider interface.

Modifications:

Add OHttpCryptoProvider.newRandomPrivateKey(...) and add an implementation for BoringSSL and BouncyCastle

Result:

Be able to easily generate a new random key.