### PR TITLE
EVP_HPKE_KEY_new_and_init_or_throw(...) need to free key on error

### DIFF
--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSL.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSL.java
@@ -168,7 +168,12 @@ final class BoringSSL {
 
     static long EVP_HPKE_KEY_new_and_init_or_throw(long kem, byte[] privateKeyBytes) {
         long key = EVP_HPKE_KEY_new_or_throw();
-        EVP_HPKE_KEY_init_or_throw(key, kem, privateKeyBytes);
+        try {
+            EVP_HPKE_KEY_init_or_throw(key, kem, privateKeyBytes);
+        } catch (Throwable e) {
+            EVP_HPKE_KEY_cleanup_and_free(key);
+            throw e;
+        }
         return key;
     }
 


### PR DESCRIPTION
Motivation:

We need to ensure we free the newly created key if EVP_HPKE_KEY_new_and_init_or_throw throws while the key is init.

Modifications:

Correcly free key on error

Result:

No more possible memory leak