### PR TITLE
Only generate byte[] of nonce_info and key_info once

### DIFF
--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCryptoReceiver.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCryptoReceiver.java
@@ -104,12 +104,12 @@ public final class OHttpCryptoReceiver extends OHttpCrypto {
         this.context = provider.setupHPKEBaseR(HPKEMode.Base, ciphersuite.kem(), ciphersuite.kdf(),
                 ciphersuite.aead(), encapsulatedKey, keyPair, ciphersuite.createInfo(configuration));
         if (builder.forcedResponseNonce == null) {
-            this.responseNonce = builder.ciphersuite.createResponseNonce();
+            this.responseNonce = ciphersuite.createResponseNonce();
         } else {
             this.responseNonce = builder.forcedResponseNonce;
         }
-        this.aead = builder.ciphersuite.createResponseAead(provider, this.context, encapsulatedKey,
-                this.responseNonce, configuration);
+        this.aead = ciphersuite.createResponseAEAD(provider, this.context, encapsulatedKey,
+                this.responseNonce, configuration.responseExportContext());
     }
 
     /**

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCryptoSender.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCryptoSender.java
@@ -130,8 +130,8 @@ public final class OHttpCryptoSender extends OHttpCrypto {
         }
         byte[] responseNonce = new byte[ciphersuite().responseNonceLength()];
         in.readBytes(responseNonce);
-        this.aead = ciphersuite.createResponseAead(
-                provider, context, context.encapsulation(), responseNonce, configuration);
+        this.aead = ciphersuite.createResponseAEAD(
+                provider, context, context.encapsulation(), responseNonce, configuration.responseExportContext());
         return true;
     }
 


### PR DESCRIPTION
Motivation:

We can store the byte[] of nonce_info and key_info in a static final field and so reduce the overhead of generating these from a string all the time

Modifications:

- Only generate byte[] once and store in final field.
- Cleanup internal API

Result:

Reduce overhead