### PR TITLE
Replace OHttpCryptoReceiver.Builder.setServerKeys(...) with OHttpCryp…

### DIFF
--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCiphersuite.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCiphersuite.java
@@ -87,13 +87,12 @@ public final class OHttpCiphersuite {
     /*
      * See https://ietf-wg-ohai.github.io/oblivious-http/draft-ietf-ohai-ohttp.html#section-4.3
      */
-    byte[] createInfo(OHttpCryptoConfiguration configuration) {
-        byte[] exportContext = configuration.requestExportContext();
-        byte[] ret = new byte[exportContext.length + 8];
+    byte[] createInfo(byte[] requestExportContext) {
+        byte[] ret = new byte[requestExportContext.length + 1 + ENCODED_LENGTH];
         ByteBuf buf = Unpooled.wrappedBuffer(ret);
         try {
             buf.writerIndex(0)
-                    .writeBytes(exportContext)
+                    .writeBytes(requestExportContext)
                     .writeByte(0);
             encode(buf);
             return ret;

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCryptoSender.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCryptoSender.java
@@ -94,7 +94,7 @@ public final class OHttpCryptoSender extends OHttpCrypto {
         AsymmetricKeyParameter pkR = requireNonNull(builder.receiverPublicKey, "receiverPublicKey");
         AsymmetricCipherKeyPair forcedEphemeralKeyPair = builder.forcedEphemeralKeyPair;
         this.context = this.provider.setupHPKEBaseS(HPKEMode.Base, ciphersuite.kem(),
-                ciphersuite.kdf(), ciphersuite.aead(), pkR, ciphersuite.createInfo(configuration),
+                ciphersuite.kdf(), ciphersuite.aead(), pkR, ciphersuite.createInfo(configuration.requestExportContext()),
                 forcedEphemeralKeyPair);
     }
 

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
@@ -283,7 +283,7 @@ public class OHttpServerCodec extends MessageToMessageCodec<HttpObject, HttpObje
             receiver = OHttpCryptoReceiver.newBuilder()
                     .setOHttpCryptoProvider(provider)
                     .setConfiguration(version())
-                    .setServerKeys(keys)
+                    .setSenderPrivateKey(keys.getKeyPair(ciphersuite))
                     .setCiphersuite(ciphersuite)
                     .setEncapsulatedKey(encapsulatedKey)
                     .build();

--- a/codec-ohttp/src/test/java/io/netty/incubator/codec/ohttp/OHttpCryptoTest.java
+++ b/codec-ohttp/src/test/java/io/netty/incubator/codec/ohttp/OHttpCryptoTest.java
@@ -117,7 +117,7 @@ public class OHttpCryptoTest {
                 AEAD.AES_GCM128);
 
         assertEquals("6d6573736167652f626874747020726571756573740001002000010001",
-                ByteBufUtil.hexDump(ciphersuite.createInfo(OHttpVersionDraft.INSTANCE)));
+                ByteBufUtil.hexDump(ciphersuite.createInfo(OHttpVersionDraft.INSTANCE.requestExportContext())));
 
         AsymmetricKeyParameter receiverPublicKey
                 = senderProvider.deserializePublicKey(KEM.X25519_SHA256, kpR.publicParameters().encoded());
@@ -157,7 +157,7 @@ public class OHttpCryptoTest {
                 try (OHttpCryptoReceiver receiver = OHttpCryptoReceiver.newBuilder()
                         .setOHttpCryptoProvider(receiverProvider)
                         .setConfiguration(OHttpVersionDraft.INSTANCE)
-                        .setServerKeys(serverKeys)
+                        .setSenderPrivateKey(serverKeys.getKeyPair(ciphersuite))
                         .setCiphersuite(receiverCiphersuite)
                         .setEncapsulatedKey(receiverEncapsulatedKey)
                         .setForcedResponseNonce(ByteBufUtil.decodeHexDump("c789e7151fcba46158ca84b04464910d"))


### PR DESCRIPTION
…toReceiver.Builder.setSenderPrivateKey(...)

Motivation:

OHttpCryptoReceiver.Builder doesnt need to know anything about OHttpServerKeys. Let's just pass in the private key directly

Modifications:

Replace OHttpCryptoReceiver.Builder.setServerKeys(...) with OHttpCryptoReceiver.Builder.setSenderPrivateKey(...)

Result:

API cleanup