### PR TITLE
Move generating of random response nonce to OHttpCryptoReceiver

### DIFF
--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCiphersuite.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCiphersuite.java
@@ -27,13 +27,10 @@ import io.netty.handler.codec.DecoderException;
 import org.bouncycastle.util.Arrays;
 
 import java.nio.charset.StandardCharsets;
-import java.security.SecureRandom;
-import java.util.Random;
 
 import static java.util.Objects.requireNonNull;
 
 public final class OHttpCiphersuite {
-    private static final Random RAND = new SecureRandom();
 
     private static final int ENCODED_LENGTH = 7;
     private static final byte[] KEY_INFO  = "key".getBytes(StandardCharsets.US_ASCII);
@@ -55,7 +52,6 @@ public final class OHttpCiphersuite {
     public int responseNonceLength() {
         return Math.max(aead.nk(), aead.nn());
     }
-
 
     public int encapsulatedKeyLength() {
         return kem.nenc();
@@ -118,12 +114,6 @@ public final class OHttpCiphersuite {
         } catch (Exception e) {
             throw new DecoderException("invalid ciphersuite", e);
         }
-    }
-
-    byte[] createResponseNonce() {
-        byte[] ret = new byte[responseNonceLength()];
-        RAND.nextBytes(ret);
-        return ret;
     }
 
     /*

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCryptoReceiver.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCryptoReceiver.java
@@ -23,12 +23,17 @@ import io.netty.incubator.codec.hpke.HPKEMode;
 import io.netty.incubator.codec.hpke.HPKERecipientContext;
 import io.netty.incubator.codec.hpke.OHttpCryptoProvider;
 
+import java.security.SecureRandom;
+import java.util.Random;
+
 import static java.util.Objects.requireNonNull;
 
 /**
  * {@link OHttpCryptoReceiver} handles all the server-side crypto for an OHTTP request/response.
  */
 public final class OHttpCryptoReceiver extends OHttpCrypto {
+    private static final Random RAND = new SecureRandom();
+
     private final OHttpCryptoConfiguration configuration;
     private final HPKERecipientContext context;
     private final byte[] responseNonce;
@@ -97,7 +102,8 @@ public final class OHttpCryptoReceiver extends OHttpCrypto {
         OHttpCryptoProvider provider = requireNonNull(builder.provider, "provider");
         AsymmetricCipherKeyPair keyPair = requireNonNull(builder.privateKey, "privateKey");
         if (builder.forcedResponseNonce == null) {
-            this.responseNonce = ciphersuite.createResponseNonce();
+            this.responseNonce = new byte[ciphersuite.responseNonceLength()];
+            RAND.nextBytes(responseNonce);
         } else {
             this.responseNonce = builder.forcedResponseNonce;
         }


### PR DESCRIPTION
Motivation:

The generating of the random response nonce does not really belong into OHttpCipherSuite.

Modifications:

Remove method to generate random response nonce from OHttpCipherSuite and handle it directly in the OHttpCryptoReceiver

Result:

Code cleanup