### PR TITLE
OHttpChunkFramer.decodePrefix(...) should also declare throws

### DIFF
--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpChunkFramer.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpChunkFramer.java
@@ -46,8 +46,9 @@ public interface OHttpChunkFramer<T> {
         /**
          * Decode the initial bytes of the HTTP content.
          * @return true on success, on false if more bytes are needed.
+         * @throws CryptoException if the prefix cannot be decoded.
          */
-        boolean decodePrefix(ByteBuf in);
+        boolean decodePrefix(ByteBuf in) throws CryptoException;
 
         /**
          * @return true if the prefix has not been decoded yet.

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpRequestResponseContext.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpRequestResponseContext.java
@@ -133,7 +133,7 @@ abstract class OHttpRequestResponseContext {
      * Decode the initial bytes of the HTTP content.
      * @return true on success, on false if more bytes are needed.
      */
-    protected abstract boolean decodePrefix(ByteBuf in);
+    protected abstract boolean decodePrefix(ByteBuf in) throws CryptoException;
 
     /**
      * Decrypt a chunk.
@@ -174,7 +174,7 @@ abstract class OHttpRequestResponseContext {
         }
 
         @Override
-        public boolean decodePrefix(ByteBuf in) {
+        public boolean decodePrefix(ByteBuf in) throws CryptoException {
             if (decodedPrefix) {
                 throw new IllegalStateException("Prefix already decoded");
             }


### PR DESCRIPTION
Motivation:

Let's make things more consistent by also adding a throws to OHttpChunkFramer.decodePrefix(...)

Modifications:

Add throws to signature

Result:

More consistent API