### PR TITLE
Also add Specification-* entries to MANIFEST.MF

### DIFF
--- a/codec-bhttp/pom.xml
+++ b/codec-bhttp/pom.xml
@@ -43,6 +43,7 @@
                             <archive>
                                 <manifest>
                                     <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                    <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                                 </manifest>
                                 <manifestEntries>
                                     <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>

--- a/codec-ohttp-hpke-bouncycastle/pom.xml
+++ b/codec-ohttp-hpke-bouncycastle/pom.xml
@@ -43,6 +43,7 @@
                         <archive>
                             <manifest>
                                 <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                             </manifest>
                             <manifestEntries>
                                 <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>

--- a/codec-ohttp-hpke-classes-boringssl/pom.xml
+++ b/codec-ohttp-hpke-classes-boringssl/pom.xml
@@ -45,6 +45,7 @@
                             <archive>
                                 <manifest>
                                     <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                    <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                                 </manifest>
                                 <manifestEntries>
                                     <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>

--- a/codec-ohttp-hpke-native-boringssl/pom.xml
+++ b/codec-ohttp-hpke-native-boringssl/pom.xml
@@ -536,6 +536,7 @@
                             <archive>
                                 <manifest>
                                     <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                    <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                                 </manifest>
                                 <manifestEntries>
                                     <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
@@ -555,6 +556,7 @@
                             <archive>
                                 <manifest>
                                     <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                    <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                                 </manifest>
                                 <manifestEntries>
                                     <Automatic-Module-Name>${javaModuleNameWithClassifier}</Automatic-Module-Name>

--- a/codec-ohttp-hpke/pom.xml
+++ b/codec-ohttp-hpke/pom.xml
@@ -43,6 +43,7 @@
                             <archive>
                                 <manifest>
                                     <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                    <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                                 </manifest>
                                 <manifestEntries>
                                     <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>

--- a/codec-ohttp/pom.xml
+++ b/codec-ohttp/pom.xml
@@ -44,6 +44,7 @@
               <archive>
                 <manifest>
                   <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                  <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                 </manifest>
                 <manifestEntries>
                   <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>


### PR DESCRIPTION
Motivation:

Some tools depend on the Specification-* entries in the MANIFEST.MF. Unfortunaly
 we don't add these at the moment

Modifications:

Configure plugin to also add the Specification-* entries

Result:

MANIFEST.MF contains Specification-* entries