### PR TITLE
Allow *CryptoContext to give a hint which type of buffer is preferred

### DIFF
--- a/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleAEADCryptoContext.java
+++ b/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleAEADCryptoContext.java
@@ -63,6 +63,11 @@ final class BouncyCastleAEADCryptoContext implements AEADContext {
     }
 
     @Override
+    public boolean isDirectBufferPreferred() {
+        return false;
+    }
+
+    @Override
     public void close() {
         closed = true;
     }

--- a/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleHPKERecipientContext.java
+++ b/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleHPKERecipientContext.java
@@ -40,4 +40,9 @@ final class BouncyCastleHPKERecipientContext extends BouncyCastleHPKEContext imp
         checkClosed();
         open.execute(aad, ct, out);
     }
+
+    @Override
+    public boolean isDirectBufferPreferred() {
+        return false;
+    }
 }

--- a/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleHPKESenderContext.java
+++ b/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleHPKESenderContext.java
@@ -45,4 +45,9 @@ final class BouncyCastleHPKESenderContext extends BouncyCastleHPKEContext implem
         checkClosed();
         seal.execute(aad, pt, out);
     }
+
+    @Override
+    public boolean isDirectBufferPreferred() {
+        return false;
+    }
 }

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAEADContext.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAEADContext.java
@@ -88,6 +88,11 @@ final class BoringSSLAEADContext extends BoringSSLCryptoContext implements AEADC
         }
     }
 
+    @Override
+    public boolean isDirectBufferPreferred() {
+        return true;
+    }
+
     private static final class Nonce {
         private final ByteBuf nonce;
         private final long nonceAddress;

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKERecipientContext.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKERecipientContext.java
@@ -46,4 +46,9 @@ final class BoringSSLHPKERecipientContext extends BoringSSLHPKEContext implement
             throw new CryptoException("open(...) failed");
         }
     }
+
+    @Override
+    public boolean isDirectBufferPreferred() {
+        return true;
+    }
 }

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKESenderContext.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKESenderContext.java
@@ -57,4 +57,9 @@ final class BoringSSLHPKESenderContext extends BoringSSLHPKEContext
             throw new CryptoException("seal(...) failed");
         }
     }
+
+    @Override
+    public boolean isDirectBufferPreferred() {
+        return true;
+    }
 }

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/CryptoDecryptContext.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/CryptoDecryptContext.java
@@ -32,4 +32,12 @@ public interface CryptoDecryptContext extends CryptoContext {
      * @throws      CryptoException in case of an error.
      */
     void open(ByteBuf aad, ByteBuf ct, ByteBuf out) throws CryptoException;
+
+    /**
+     * Returns {@code true} if {@link ByteBuf}s that are direct should be used to avoid extra memory copies,
+     * {@code false} otherwise.
+     *
+     * @return if direct buffer is preferred.
+     */
+    boolean isDirectBufferPreferred();
 }

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/CryptoEncryptContext.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/CryptoEncryptContext.java
@@ -32,4 +32,12 @@ public interface CryptoEncryptContext extends CryptoContext {
      * @throws      CryptoException in case of an error.
      */
     void seal(ByteBuf aad, ByteBuf pt, ByteBuf out) throws CryptoException;
+
+    /**
+     * Returns {@code true} if {@link ByteBuf}s that are direct should be used to avoid extra memory copies,
+     * {@code false} otherwise.
+     *
+     * @return if direct buffer is preferred.
+     */
+    boolean isDirectBufferPreferred();
 }


### PR DESCRIPTION
Motivation:

We should allow the CryptoContext to give a hint which type of buffer is preferred by it to minimize memory copies. For example BoringSSL based implementation prefers a direct buffer (as it need to act on the memory address) while the Bouncycastle implementation prefers a heap based buffer as it only offer methods to act on byte[] arrays.

Modifications:

- Add isDirectBufferPreferred() method to CryptoDecryptContext and CryptoEncryptContext
- Add implementation for these methods
- Use the new methods to use the correct buffer type for the AAD buffer.

Result:

Less memory copies / allocations