### PR TITLE
Pass ByteBufAllocator to methods to allow usage for allocations

### DIFF
--- a/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleAEADCryptoContext.java
+++ b/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleAEADCryptoContext.java
@@ -16,6 +16,7 @@
 package io.netty.incubator.codec.hpke.bouncycastle;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.incubator.codec.hpke.AEADContext;
 import io.netty.incubator.codec.hpke.CryptoException;
 import org.bouncycastle.crypto.InvalidCipherTextException;
@@ -45,13 +46,13 @@ final class BouncyCastleAEADCryptoContext implements AEADContext {
     }
 
     @Override
-    public void seal(ByteBuf aad, ByteBuf pt, ByteBuf out) throws CryptoException {
+    public void seal(ByteBufAllocator alloc, ByteBuf aad, ByteBuf pt, ByteBuf out) throws CryptoException {
         checkClosed();
         seal.execute(aad, pt, out);
     }
 
     @Override
-    public void open(ByteBuf aad, ByteBuf ct, ByteBuf out) throws CryptoException {
+    public void open(ByteBufAllocator alloc, ByteBuf aad, ByteBuf ct, ByteBuf out) throws CryptoException {
         checkClosed();
         open.execute(aad, ct, out);
     }

--- a/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleHPKERecipientContext.java
+++ b/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleHPKERecipientContext.java
@@ -16,6 +16,7 @@
 package io.netty.incubator.codec.hpke.bouncycastle;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.incubator.codec.hpke.CryptoException;
 import io.netty.incubator.codec.hpke.HPKERecipientContext;
 import org.bouncycastle.crypto.InvalidCipherTextException;
@@ -36,7 +37,7 @@ final class BouncyCastleHPKERecipientContext extends BouncyCastleHPKEContext imp
     }
 
     @Override
-    public void open(ByteBuf aad, ByteBuf ct, ByteBuf out) throws CryptoException {
+    public void open(ByteBufAllocator alloc, ByteBuf aad, ByteBuf ct, ByteBuf out) throws CryptoException {
         checkClosed();
         open.execute(aad, ct, out);
     }

--- a/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleHPKESenderContext.java
+++ b/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleHPKESenderContext.java
@@ -16,6 +16,7 @@
 package io.netty.incubator.codec.hpke.bouncycastle;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.incubator.codec.hpke.CryptoException;
 import io.netty.incubator.codec.hpke.HPKESenderContext;
 import org.bouncycastle.crypto.InvalidCipherTextException;
@@ -41,7 +42,7 @@ final class BouncyCastleHPKESenderContext extends BouncyCastleHPKEContext implem
     }
 
     @Override
-    public void seal(ByteBuf aad, ByteBuf pt, ByteBuf out) throws CryptoException {
+    public void seal(ByteBufAllocator alloc, ByteBuf aad, ByteBuf pt, ByteBuf out) throws CryptoException {
         checkClosed();
         seal.execute(aad, pt, out);
     }

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKERecipientContext.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKERecipientContext.java
@@ -16,6 +16,7 @@
 package io.netty.incubator.codec.hpke.boringssl;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.incubator.codec.hpke.CryptoException;
 import io.netty.incubator.codec.hpke.HPKERecipientContext;
 
@@ -31,7 +32,7 @@ final class BoringSSLHPKERecipientContext extends BoringSSLHPKEContext implement
         }
 
         @Override
-        int execute(long ctx, long ad, int adLen, long in, int inLen, long out, int outLen) {
+        int execute(long ctx, ByteBufAllocator alloc,  long ad, int adLen, long in, int inLen, long out, int outLen) {
             return BoringSSL.EVP_HPKE_CTX_open(ctx, out, outLen, in, inLen, ad, adLen);
         }
     };
@@ -41,8 +42,8 @@ final class BoringSSLHPKERecipientContext extends BoringSSLHPKEContext implement
     }
 
     @Override
-    public void open(ByteBuf aad, ByteBuf ct, ByteBuf out) throws CryptoException {
-        if (!OPEN.execute(checkClosedAndReturnCtx(), aad, ct, out)) {
+    public void open(ByteBufAllocator alloc, ByteBuf aad, ByteBuf ct, ByteBuf out) throws CryptoException {
+        if (!OPEN.execute(checkClosedAndReturnCtx(), alloc, aad, ct, out)) {
             throw new CryptoException("open(...) failed");
         }
     }

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKESenderContext.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKESenderContext.java
@@ -16,8 +16,8 @@
 package io.netty.incubator.codec.hpke.boringssl;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.incubator.codec.hpke.CryptoException;
-import io.netty.incubator.codec.hpke.HPKERecipientContext;
 import io.netty.incubator.codec.hpke.HPKESenderContext;
 
 /**
@@ -34,7 +34,7 @@ final class BoringSSLHPKESenderContext extends BoringSSLHPKEContext
         }
 
         @Override
-        int execute(long ctx, long ad, int adLen, long in, int inLen, long out, int outLen) {
+        int execute(long ctx, ByteBufAllocator alloc, long ad, int adLen, long in, int inLen, long out, int outLen) {
             return BoringSSL.EVP_HPKE_CTX_seal(ctx, out, outLen, in, inLen, ad, adLen);
         }
     };
@@ -52,8 +52,8 @@ final class BoringSSLHPKESenderContext extends BoringSSLHPKEContext
     }
 
     @Override
-    public void seal(ByteBuf aad, ByteBuf pt, ByteBuf out) throws CryptoException {
-        if (!SEAL.execute(checkClosedAndReturnCtx(), aad, pt, out)) {
+    public void seal(ByteBufAllocator alloc, ByteBuf aad, ByteBuf pt, ByteBuf out) throws CryptoException {
+        if (!SEAL.execute(checkClosedAndReturnCtx(), alloc, aad, pt, out)) {
             throw new CryptoException("seal(...) failed");
         }
     }

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/CryptoDecryptContext.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/CryptoDecryptContext.java
@@ -16,6 +16,7 @@
 package io.netty.incubator.codec.hpke;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 
 /**
  * {@link CryptoContext} that can be used for decryption.
@@ -26,12 +27,13 @@ public interface CryptoDecryptContext extends CryptoContext {
      * Authenticate and decrypt data. The {@link ByteBuf#readerIndex()} will be increased by the amount of
      * data read and {@link ByteBuf#writerIndex()} by the bytes written.
      *
+     * @param alloc {@link ByteBufAllocator} which might be used to do extra allocations.
      * @param aad   the AAD buffer
      * @param ct    the data to decrypt
      * @param out   the buffer for writing into.
      * @throws      CryptoException in case of an error.
      */
-    void open(ByteBuf aad, ByteBuf ct, ByteBuf out) throws CryptoException;
+    void open(ByteBufAllocator alloc, ByteBuf aad, ByteBuf ct, ByteBuf out) throws CryptoException;
 
     /**
      * Returns {@code true} if {@link ByteBuf}s that are direct should be used to avoid extra memory copies,

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/CryptoEncryptContext.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/CryptoEncryptContext.java
@@ -16,6 +16,7 @@
 package io.netty.incubator.codec.hpke;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 
 /**
  * {@link CryptoContext} that can be used for encryption.
@@ -26,12 +27,13 @@ public interface CryptoEncryptContext extends CryptoContext {
      * Authenticate and encrypt data. The {@link ByteBuf#readerIndex()} will be increased by the amount of
      * data read and {@link ByteBuf#writerIndex()} by the bytes written.
      *
+     * @param alloc {@link ByteBufAllocator} which might be used to do extra allocations.
      * @param aad   the AAD buffer
      * @param pt    the data to encrypt.
      * @param out   the buffer for writing into
      * @throws      CryptoException in case of an error.
      */
-    void seal(ByteBuf aad, ByteBuf pt, ByteBuf out) throws CryptoException;
+    void seal(ByteBufAllocator alloc, ByteBuf aad, ByteBuf pt, ByteBuf out) throws CryptoException;
 
     /**
      * Returns {@code true} if {@link ByteBuf}s that are direct should be used to avoid extra memory copies,

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCrypto.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCrypto.java
@@ -16,6 +16,7 @@
 package io.netty.incubator.codec.ohttp;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.incubator.codec.hpke.CryptoDecryptContext;
 import io.netty.incubator.codec.hpke.CryptoEncryptContext;
@@ -57,14 +58,16 @@ public abstract class OHttpCrypto implements AutoCloseable {
     /**
      * Encrypt a message of a given length and write the encrypted data to a buffer.
      *
+     * @param alloc             {@link ByteBufAllocator} which might be used to do extra allocations.
      * @param message           the message
      * @param messageLength     the length of the message
      * @param isFinal           {@code true} if this is the final message.
      * @param out               {@link ByteBuf} into which the encrypted data is written.
      * @throws CryptoException  thrown when an error happens.
      */
-    public final void encrypt(ByteBuf message, int messageLength, boolean isFinal, ByteBuf out) throws CryptoException {
-        encryptCrypto().seal(aad(isFinal && useFinalAad(), encryptCrypto().isDirectBufferPreferred()),
+    public final void encrypt(ByteBufAllocator alloc, ByteBuf message, int messageLength, boolean isFinal, ByteBuf out)
+            throws CryptoException {
+        encryptCrypto().seal(alloc, aad(isFinal && useFinalAad(), encryptCrypto().isDirectBufferPreferred()),
                 message.slice(message.readerIndex(), messageLength), out);
         message.skipBytes(messageLength);
     }
@@ -72,15 +75,16 @@ public abstract class OHttpCrypto implements AutoCloseable {
     /**
      * Decrypt a message of a given length and write the decrypted data to a buffer.
      *
+     * @param alloc             {@link ByteBufAllocator} which might be used to do extra allocations.
      * @param message           the message
      * @param messageLength     the length of the message
      * @param isFinal           {@code true} if this is the final message.
      * @param out               {@link ByteBuf} into which the decrypted data is written.
      * @throws CryptoException  thrown when an error happens.
      */
-    public final void decrypt(ByteBuf message, int messageLength, boolean isFinal, ByteBuf out) throws CryptoException {
-        decryptCrypto().open(
-                aad(isFinal && useFinalAad(), decryptCrypto().isDirectBufferPreferred()),
+    public final void decrypt(ByteBufAllocator alloc, ByteBuf message, int messageLength, boolean isFinal, ByteBuf out)
+            throws CryptoException {
+        decryptCrypto().open(alloc, aad(isFinal && useFinalAad(), decryptCrypto().isDirectBufferPreferred()),
                 message.slice(message.readerIndex(), messageLength), out);
         message.skipBytes(messageLength);
     }

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpVersionDraft.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpVersionDraft.java
@@ -15,6 +15,7 @@
  */
 package io.netty.incubator.codec.ohttp;
 
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.incubator.codec.hpke.CryptoException;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.CorruptedFrameException;
@@ -66,24 +67,25 @@ public final class OHttpVersionDraft implements OHttpVersion {
     }
 
     @Override
-    public void parse(ByteBuf in, boolean completeBodyReceived, Decoder decoder, List<Object> out)
-            throws CryptoException {
+    public void parse(ByteBufAllocator alloc, ByteBuf in, boolean completeBodyReceived,
+                      Decoder decoder, List<Object> out) throws CryptoException {
         if (completeBodyReceived) {
-            if (decoder.isPrefixNeeded() && !decoder.decodePrefix(in)) {
+            if (decoder.isPrefixNeeded() && !decoder.decodePrefix(alloc, in)) {
                 throw new CorruptedFrameException("Prefix is truncated");
             }
-            decoder.decodeChunk(in, in.readableBytes(), true, out);
+            decoder.decodeChunk(alloc, in, in.readableBytes(), true, out);
         }
     }
 
     @Override
-    public void serialize(HttpObject msg, Encoder<HttpObject> encoder, ByteBuf out) throws CryptoException {
+    public void serialize(ByteBufAllocator alloc, HttpObject msg, Encoder<HttpObject> encoder, ByteBuf out)
+            throws CryptoException {
         if (!(msg instanceof LastHttpContent)) {
             throw new EncoderException("OHTTP version only supports FullHttpMessage");
         }
         if (encoder.isPrefixNeeded()) {
-            encoder.encodePrefix(out);
+            encoder.encodePrefix(alloc, out);
         }
-        encoder.encodeChunk(msg, out);
+        encoder.encodeChunk(alloc, msg, out);
     }
 }

--- a/codec-ohttp/src/test/java/io/netty/incubator/codec/ohttp/OHttpCryptoTest.java
+++ b/codec-ohttp/src/test/java/io/netty/incubator/codec/ohttp/OHttpCryptoTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty.incubator.codec.ohttp;
 
+import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.incubator.codec.hpke.AsymmetricCipherKeyPair;
 import io.netty.incubator.codec.hpke.AsymmetricKeyParameter;
 import io.netty.incubator.codec.hpke.OHttpCryptoProvider;
@@ -148,7 +149,8 @@ public class OHttpCryptoTest {
             ByteBuf encodedResponse = Unpooled.buffer();
             ByteBuf decodedResponse = Unpooled.buffer();
             try {
-                sender.encrypt(Unpooled.wrappedBuffer(request), request.length, true, encrypted);
+                sender.encrypt(UnpooledByteBufAllocator.DEFAULT, Unpooled.wrappedBuffer(request),
+                        request.length, true, encrypted);
                 sender.writeHeader(encodedRequest);
                 encodedRequest.writeBytes(encrypted);
 
@@ -172,12 +174,13 @@ public class OHttpCryptoTest {
                         .setForcedResponseNonce(ByteBufUtil.decodeHexDump("c789e7151fcba46158ca84b04464910d"))
                         .build()) {
 
-                    receiver.decrypt(encodedRequest, encodedRequest.readableBytes(), true, decodedRequest);
+                    receiver.decrypt(UnpooledByteBufAllocator.DEFAULT, encodedRequest, encodedRequest.readableBytes(),
+                            true, decodedRequest);
                     assertEquals(requestBuffer, decodedRequest);
 
                     // Receiver encodes response
 
-                    receiver.encrypt(responseBuffer, response.length, true, enc);
+                    receiver.encrypt(UnpooledByteBufAllocator.DEFAULT, responseBuffer, response.length, true, enc);
                     receiver.writeResponseNonce(encodedResponse);
                     encodedResponse.writeBytes(enc);
                     assertEquals("c789e7151fcba46158ca84b04464910d86f9013e404feea014e7be4a441f234f857fbd",
@@ -188,7 +191,8 @@ public class OHttpCryptoTest {
                     encodedResponse.readerIndex(0);
                     sender.readResponseNonce(encodedResponse);
 
-                    sender.decrypt(encodedResponse, encodedResponse.readableBytes(), true, decodedResponse);
+                    sender.decrypt(UnpooledByteBufAllocator.DEFAULT, encodedResponse, encodedResponse.readableBytes(),
+                            true, decodedResponse);
                     assertEquals(responseBuffer.readerIndex(0), decodedResponse);
                 }
             } finally {


### PR DESCRIPTION
Motivation:

We might need to do temporary allocations in our implementations, to minimize the overhead we should allow the user to pass the ByteBufAllocator that should be used.

Modifications:

- Change methods signatures to take ByteBufAllocator as well
- Use allocator to allocate the used Nonce and so reduce overhead

Result:

Less overhead