### PR TITLE
Rename method to be less missleading

### DIFF
--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCryptoReceiver.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCryptoReceiver.java
@@ -56,7 +56,7 @@ public final class OHttpCryptoReceiver extends OHttpCrypto {
             return this;
         }
 
-        public Builder setSenderPrivateKey(AsymmetricCipherKeyPair privateKey) {
+        public Builder setPrivateKey(AsymmetricCipherKeyPair privateKey) {
             this.privateKey = privateKey;
             return this;
         }

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
@@ -286,7 +286,7 @@ public class OHttpServerCodec extends MessageToMessageCodec<HttpObject, HttpObje
             receiver = OHttpCryptoReceiver.newBuilder()
                     .setOHttpCryptoProvider(provider)
                     .setConfiguration(version())
-                    .setSenderPrivateKey(keys.getKeyPair(ciphersuite))
+                    .setPrivateKey(keys.getKeyPair(ciphersuite))
                     .setCiphersuite(ciphersuite)
                     .setEncapsulatedKey(encapsulatedKey)
                     .build();

--- a/codec-ohttp/src/test/java/io/netty/incubator/codec/ohttp/OHttpCryptoTest.java
+++ b/codec-ohttp/src/test/java/io/netty/incubator/codec/ohttp/OHttpCryptoTest.java
@@ -168,7 +168,7 @@ public class OHttpCryptoTest {
                 try (OHttpCryptoReceiver receiver = OHttpCryptoReceiver.newBuilder()
                         .setOHttpCryptoProvider(receiverProvider)
                         .setConfiguration(OHttpVersionDraft.INSTANCE)
-                        .setSenderPrivateKey(serverKeys.getKeyPair(ciphersuite))
+                        .setPrivateKey(serverKeys.getKeyPair(ciphersuite))
                         .setCiphersuite(receiverCiphersuite)
                         .setEncapsulatedKey(receiverEncapsulatedKey)
                         .setForcedResponseNonce(ByteBufUtil.decodeHexDump("c789e7151fcba46158ca84b04464910d"))


### PR DESCRIPTION
Motivation:

Currently the method name is quite missleading, let's fix this.

Modifications:

Rename setSenderPrivateKey(...) to setPrivateKey(...)

Result:

Less missleading method name