### PR TITLE
Move code out of OHttpCipherSuite into OHttpCrypto

### DIFF
--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCryptoReceiver.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCryptoReceiver.java
@@ -106,9 +106,9 @@ public final class OHttpCryptoReceiver extends OHttpCrypto {
             this.responseNonce = builder.forcedResponseNonce;
         }
         this.context = provider.setupHPKEBaseR(ciphersuite.kem(), ciphersuite.kdf(), ciphersuite.aead(),
-                encapsulatedKey, keyPair, ciphersuite.createInfo(configuration.requestExportContext()));
+                encapsulatedKey, keyPair, createInfo(ciphersuite, configuration.requestExportContext()));
         try {
-            this.aead = ciphersuite.createResponseAEAD(provider, context, encapsulatedKey,
+            this.aead = createResponseAEAD(provider, context, ciphersuite.aead(), encapsulatedKey,
                     this.responseNonce, configuration.responseExportContext());
         } catch (Throwable cause) {
             // Close context before rethrowing as otherwise we might leak resources.

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCryptoSender.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCryptoSender.java
@@ -94,7 +94,7 @@ public final class OHttpCryptoSender extends OHttpCrypto {
         AsymmetricCipherKeyPair forcedEphemeralKeyPair = builder.forcedEphemeralKeyPair;
         this.context = this.provider.setupHPKEBaseS(ciphersuite.kem(),
                 ciphersuite.kdf(), ciphersuite.aead(), pkR,
-                ciphersuite.createInfo(configuration.requestExportContext()), forcedEphemeralKeyPair);
+                createInfo(ciphersuite, configuration.requestExportContext()), forcedEphemeralKeyPair);
     }
 
     /**
@@ -129,8 +129,9 @@ public final class OHttpCryptoSender extends OHttpCrypto {
         }
         byte[] responseNonce = new byte[ciphersuite().responseNonceLength()];
         in.readBytes(responseNonce);
-        this.aead = ciphersuite.createResponseAEAD(
-                provider, context, context.encapsulation(), responseNonce, configuration.responseExportContext());
+        this.aead = createResponseAEAD(
+                provider, context, ciphersuite().aead(), context.encapsulation(), responseNonce,
+                configuration.responseExportContext());
         return true;
     }
 

--- a/codec-ohttp/src/test/java/io/netty/incubator/codec/ohttp/OHttpCryptoTest.java
+++ b/codec-ohttp/src/test/java/io/netty/incubator/codec/ohttp/OHttpCryptoTest.java
@@ -127,7 +127,8 @@ public class OHttpCryptoTest {
                 AEAD.AES_GCM128);
 
         assertEquals("6d6573736167652f626874747020726571756573740001002000010001",
-                ByteBufUtil.hexDump(ciphersuite.createInfo(OHttpVersionDraft.INSTANCE.requestExportContext())));
+                ByteBufUtil.hexDump(OHttpCrypto.createInfo(ciphersuite,
+                        OHttpVersionDraft.INSTANCE.requestExportContext())));
 
         AsymmetricKeyParameter receiverPublicKey
                 = senderProvider.deserializePublicKey(KEM.X25519_SHA256, kpR.publicParameters().encoded());


### PR DESCRIPTION
Motivation:

Some of the code that was part of OHttpCipherSuite makes more sense in OHttpCrypto in terms of seperation

Modifications:

Move code

Result:

Cleanup