### PR TITLE
Update to latest java version

### DIFF
--- a/docker/docker-compose.centos-7.117.yaml
+++ b/docker/docker-compose.centos-7.117.yaml
@@ -6,7 +6,7 @@ services:
     image: netty-codec-ohttp-centos7:centos-7-17
     build:
       args:
-        java_version : "17.0.9-zulu"
+        java_version : "17.0.10-zulu"
 
   build:
     image: netty-codec-ohttp-centos7:centos-7-17

--- a/docker/docker-compose.centos-7.18.yaml
+++ b/docker/docker-compose.centos-7.18.yaml
@@ -6,7 +6,7 @@ services:
     image: netty-codec-ohttp-centos7:centos-7-1.8
     build:
       args:
-        java_version : "8.0.392-zulu"
+        java_version : "8.0.402-zulu"
 
   build:
     image: netty-codec-ohttp-centos7:centos-7-1.8

--- a/docker/docker-compose.centos-7.21.yaml
+++ b/docker/docker-compose.centos-7.21.yaml
@@ -6,7 +6,7 @@ services:
     image: netty-codec-ohttp-centos7:centos-7-21
     build:
       args:
-        java_version : "21.0.1-zulu"
+        java_version : "21.0.2-zulu"
 
   build:
     image: netty-codec-ohttp-centos7:centos-7-21


### PR DESCRIPTION
Motivation:

Our java versions were outdated when building via docker

Modifications:

Update to latest versions

Result:

Use latest java versions