### PR TITLE
Upload jars after workflow execution

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -54,6 +54,13 @@ jobs:
         run: ./.github/scripts/check_build_result.sh build.output
 
       - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: build-linux-x86_64-jars
+          path: |
+            **/target/*.jar
+
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: target
@@ -81,6 +88,13 @@ jobs:
 
       - name: Build project without leak detection
         run: docker-compose -f docker/docker-compose.centos-7-cross.yaml run cross-compile-aarch64-build
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: build-linux-aarch64-jars
+          path: |
+            **/target/*.jar
 
       - uses: actions/upload-artifact@v4
         if: ${{ failure() }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -82,9 +82,16 @@ jobs:
           path: '**/target/surefire-reports/TEST-*.xml'
 
       - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: build-pr-${{ matrix.setup }}-jars
+          path: |
+            **/target/*.jar
+
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
-          name: build-${{ matrix.setup }}-target
+          name: build-pr-${{ matrix.setup }}-target
           path: |
             **/target/surefire-reports/
             **/hs_err*.log


### PR DESCRIPTION
Motivation:

It is sometimes useful to be able to inspect the built jars

Modifications:

Add workflow step to upload jars

Result:

Be able to inspect built jars