### PR TITLE
Check if receiver was created before trying to close it when destroyi…

### DIFF
--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
@@ -338,7 +338,11 @@ public class OHttpServerCodec extends MessageToMessageCodec<HttpObject, HttpObje
 
         @Override
         void destroyCrypto() {
-            receiver.close();
+            // check for null as the receiver might not have been created yet if we destroy
+            // before decoding the prefix.
+            if (receiver != null) {
+                receiver.close();
+            }
         }
     }
 }


### PR DESCRIPTION
…ng the context.

Motivation:

We need to check for null before trying to close the reciver as we might not have created it yet.

Modifications:

Add null check

Result:

No more NPE possible