### PR TITLE
Correctly parse empty header values when Indeterminate-Length Message…

### DIFF
--- a/codec-bhttp/src/test/java/io/netty/incubator/codec/bhttp/BinaryHttpHeadersTest.java
+++ b/codec-bhttp/src/test/java/io/netty/incubator/codec/bhttp/BinaryHttpHeadersTest.java
@@ -49,4 +49,10 @@ public class BinaryHttpHeadersTest {
         HttpHeaders headers = BinaryHttpHeaders.newTrailers(true);
         assertThrows(IllegalArgumentException.class, () -> headers.set(":custom", "x"));
     }
+
+    @Test
+    public void emptyHeaderValue() {
+        HttpHeaders headers = BinaryHttpHeaders.newHeaders(true);
+        headers.set("name", "");
+    }
 }


### PR DESCRIPTION
…s are used.

Motivation:

We did not correctly parse Indeterminate-Length Field Sections and so produced an assertion failure when a header with an empty value was received.

Modifications:

- Fix parsing code
- Add unti tests

Result:

Correctly parse headers with empty values