### PR TITLE
Add specific Encoder/DecoderException classes for OHTTP

### DIFF
--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpClientCodec.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpClientCodec.java
@@ -233,7 +233,7 @@ public final class OHttpClientCodec extends MessageToMessageCodec<HttpObject, Ht
                 h.destroy();
             }
         } catch (CryptoException e) {
-            throw new DecoderException("failed to decrypt bytes", e);
+            throw new OHttpDecoderException("failed to decrypt bytes", e);
         }
     }
 
@@ -286,7 +286,7 @@ public final class OHttpClientCodec extends MessageToMessageCodec<HttpObject, Ht
                 out.add(ReferenceCountUtil.retain(msg));
             }
         } catch (CryptoException e) {
-            throw new EncoderException("failed to encrypt bytes", e);
+            throw new OHttpEncoderException("failed to encrypt bytes", e);
         }
     }
 

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpDecoderException.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpDecoderException.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.ohttp;
+
+import io.netty.handler.codec.DecoderException;
+
+/**
+ * Exception while decoding
+ * <a href="https://ietf-wg-ohai.github.io/oblivious-http/draft-ietf-ohai-ohttp.html">Oblivious HTTP</a>.
+ */
+public class OHttpDecoderException extends DecoderException {
+
+    /**
+     * Create a new instance
+     */
+    public OHttpDecoderException() {
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param message   the message to use.
+     * @param cause     the cause to use.
+     */
+    public OHttpDecoderException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param message   the message to use.
+     */
+    public OHttpDecoderException(String message) {
+        super(message);
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param cause     the cause to use.
+     */
+    public OHttpDecoderException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpEncoderException.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpEncoderException.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.ohttp;
+
+import io.netty.handler.codec.EncoderException;
+
+/**
+ * Exception while encoding
+ * <a href="https://ietf-wg-ohai.github.io/oblivious-http/draft-ietf-ohai-ohttp.html">Oblivious HTTP</a>.
+ */
+public class OHttpEncoderException extends EncoderException {
+
+    /**
+     * Create a new instance
+     */
+    public OHttpEncoderException() {
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param message   the message to use.
+     * @param cause     the cause to use.
+     */
+    public OHttpEncoderException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param message   the message to use.
+     */
+    public OHttpEncoderException(String message) {
+        super(message);
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param cause     the cause to use.
+     */
+    public OHttpEncoderException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
@@ -220,7 +220,7 @@ public class OHttpServerCodec extends MessageToMessageCodec<HttpObject, HttpObje
                 out.add(ReferenceCountUtil.retain(msg));
             }
         } catch (CryptoException e) {
-            throw new EncoderException("failed to encrypt bytes", e);
+            throw new OHttpEncoderException("failed to encrypt bytes", e);
         }
     }
 
@@ -243,7 +243,7 @@ public class OHttpServerCodec extends MessageToMessageCodec<HttpObject, HttpObje
         }
     }
 
-    private static final class OHttpServerDecoderException extends DecoderException {
+    private static final class OHttpServerDecoderException extends OHttpDecoderException {
         OHttpServerDecoderException(String msg, Throwable cause) {
             super(msg, cause);
         }


### PR DESCRIPTION
Motivation:

Let's better throw some specific OHTTP exceptions so its easier for other handlers in the pipeline to handle it.

Modifications:

Add two exception classes

Result:

Easier to handle exceptions caused by OHTTP