### PR TITLE
Correctly respond with plain text BAD_REQUEST when prefix can not be …

### DIFF
--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpRequestResponseContext.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpRequestResponseContext.java
@@ -127,7 +127,14 @@ abstract class OHttpRequestResponseContext {
             throw new IllegalStateException("Already destroyed");
         }
 
-        version.parse(alloc, in, completeBodyReceived, decoder, out);
+        try {
+            version.parse(alloc, in, completeBodyReceived, decoder, out);
+        } catch (RuntimeException e) {
+            if (decoder.isPrefixNeeded()) {
+                throw new CryptoException("Unable to parse prefix", e);
+            }
+            throw e;
+        }
 
         if (completeBodyReceived && in.isReadable()) {
             throw new CorruptedFrameException("OHTTP stream has extra bytes");

--- a/codec-ohttp/src/test/java/io/netty/incubator/codec/ohttp/OHttpServerCodecTest.java
+++ b/codec-ohttp/src/test/java/io/netty/incubator/codec/ohttp/OHttpServerCodecTest.java
@@ -35,6 +35,8 @@ import io.netty.incubator.codec.hpke.KDF;
 import io.netty.incubator.codec.hpke.KEM;
 import io.netty.incubator.codec.hpke.bouncycastle.BouncyCastleOHttpCryptoProvider;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Arrays;
 
@@ -92,8 +94,9 @@ public class OHttpServerCodecTest {
         assertFalse(channel.finish());
     }
 
-    @Test
-    public void testCryptoErrorProduceBadRequest() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    public void testCryptoErrorProduceBadRequest(boolean incompletePrefix) throws Exception {
         AsymmetricCipherKeyPair kpR = OHttpCryptoTest.createX25519KeyPair(BouncyCastleOHttpCryptoProvider.INSTANCE,
                 "3c168975674b2fa8e465970b79c8dcf09f1c741626480bd4c6162fc5b6a98e1a");
         byte keyId = 0x66;
@@ -121,7 +124,7 @@ public class OHttpServerCodecTest {
         assertNull(channel.readOutbound());
 
         // Write some invalid prefix so it will fail.
-        HttpContent lastContent = new DefaultLastHttpContent(Unpooled.buffer().writeZero(8));
+        HttpContent lastContent = new DefaultLastHttpContent(Unpooled.buffer().writeZero(incompletePrefix ? 1 : 8));
         assertFalse(channel.writeInbound(lastContent));
 
         FullHttpResponse response = channel.readOutbound();


### PR DESCRIPTION
…decoded

Motivation:

We need to respond with plain text if we fail to decode the prefix

Modifications:

Correctly detect if we failed to remove encapsulation and if this is the case don't try to encapsulate before responding with BAD_REQUEST

Result:

Correctly follow the RFC. Follow up of 967414f755c12692c62361fa436315e932a6e8e1