### PR TITLE
Don't leak native memory for random generated keys

### DIFF
--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAsymmetricCipherKeyPair.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAsymmetricCipherKeyPair.java
@@ -31,6 +31,12 @@ final class BoringSSLAsymmetricCipherKeyPair implements AsymmetricCipherKeyPair 
         publicKey = new BoringSSLAsymmetricKeyParameter(publicKeyBytes, false);
     }
 
+    BoringSSLAsymmetricCipherKeyPair(byte[] privateKeyBytes, byte[] publicKeyBytes) {
+        this.key = -1;
+        privateKey = new BoringSSLAsymmetricKeyParameter(privateKeyBytes, true);
+        publicKey = new BoringSSLAsymmetricKeyParameter(publicKeyBytes, false);
+    }
+
     @Override
     public BoringSSLAsymmetricKeyParameter publicParameters() {
         return publicKey;

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLOHttpCryptoProvider.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLOHttpCryptoProvider.java
@@ -177,9 +177,11 @@ public final class BoringSSLOHttpCryptoProvider implements OHttpCryptoProvider {
             if (skR instanceof BoringSSLAsymmetricCipherKeyPair) {
                 key = ((BoringSSLAsymmetricCipherKeyPair) skR).key;
                 freeKey = false;
-            } else {
+            }
+            if (key == -1) {
                 byte[] privateKeyBytes = encodedAsymmetricKeyParameter(skR.privateParameters());
                 key = BoringSSL.EVP_HPKE_KEY_new_and_init_or_throw(boringSSLKem, privateKeyBytes);
+                freeKey = true;
             }
 
             ctx = BoringSSL.EVP_HPKE_CTX_new_or_throw();
@@ -252,10 +254,7 @@ public final class BoringSSLOHttpCryptoProvider implements OHttpCryptoProvider {
             if (privateKeyBytes == null || publicKeyBytes == null) {
                 throw new IllegalStateException("Unable to generate random key");
             }
-            BoringSSLAsymmetricCipherKeyPair pair =
-                    new BoringSSLAsymmetricCipherKeyPair(key, privateKeyBytes, publicKeyBytes);
-            key = -1;
-            return pair;
+            return new BoringSSLAsymmetricCipherKeyPair(privateKeyBytes, publicKeyBytes);
         } finally {
             BoringSSL.EVP_HPKE_KEY_cleanup_and_free(key);
         }


### PR DESCRIPTION
Motivation:

We did leak native memory for random generated keys as the native memory was never freed

Modifications:

Ensure we free the native memory before return from the method

Result:

No more native memory leak for random generated keys