### PR TITLE
Correctly detect when allocation fails and return correct

### DIFF
--- a/codec-ohttp-hpke-native-boringssl/src/main/c/netty_incubator_codec_ohttp_hpke_boringssl.c
+++ b/codec-ohttp-hpke-native-boringssl/src/main/c/netty_incubator_codec_ohttp_hpke_boringssl.c
@@ -86,7 +86,11 @@ static jint netty_incubator_codec_ohttp_hpke_boringssl_EVP_AEAD_DEFAULT_TAG_LENG
 }
 
 static jlong netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_new(JNIEnv* env, jclass clazz) {
-    return (jlong) EVP_HPKE_CTX_new();
+    EVP_HPKE_CTX *ctx = EVP_HPKE_CTX_new();
+    if (ctx == NULL) {
+        return -1;
+    }
+    return (jlong) ctx;
 }
 
 static void netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_cleanup(JNIEnv* env, jclass clazz, jlong ctx) {
@@ -273,7 +277,11 @@ static jint netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_CTX_max_overhead
 }
 
 static jlong netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_new(JNIEnv* env, jclass clazz) {
-    return (jlong) EVP_HPKE_KEY_new();
+    EVP_HPKE_KEY *key = EVP_HPKE_KEY_new();
+    if (key == NULL) {
+        return -1;
+    }
+    return (jlong) key;
 }
 
 static void netty_incubator_codec_ohttp_hpke_boringssl_EVP_HPKE_KEY_free(JNIEnv* env, jclass clazz, jlong key) {


### PR DESCRIPTION
 value

Motivation:

The `BoringSSL` class handles the Java->Native (BoringSSL) calls. In `EVP_HPKE_CTX_new_or_throw` it checks to ensure that a new `EVP_HPKE_CTX`  is properly allocated (in the native heap) and that a pointer to it is returned. However, it checks this value against `-1` when a failure of the `EVP_HPKE_CTX_new()` native method (from BoringSSL) return a `NULL` (or `0`) upon failure, not a `-1`. This means that a failed context creation will result in a `NULL` pointer being return and later dereferenced by native code. The same problem exists for EVP_HPKE_CTX_new().

Modifications:

Detect NULL and return -1 so we correctly handle it in the java layer

Result:

No more possible dereferencing of NULL pointer