### PR TITLE
Correctly implement encoding / decoding Key Configuration Media Type

### DIFF
--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerKeys.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerKeys.java
@@ -20,14 +20,12 @@ import io.netty.incubator.codec.hpke.AsymmetricCipherKeyPair;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.internal.ObjectUtil;
 
-import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
 import io.netty.incubator.codec.hpke.KEM;
-import io.netty.util.internal.PlatformDependent;
 
 /**
  * Set of key pairs and cipher suites for a OHTTP server.
@@ -87,14 +85,17 @@ public final class OHttpServerKeys {
     }
 
     /**
-     * Encode {@link OHttpServerKeys} into bytes that represent {@link OHttpServerPublicKeys}, using the format
-     * described at https://ietf-wg-ohai.github.io/oblivious-http/draft-ietf-ohai-ohttp.html#section-3.1
+     * Encode {@link OHttpServerKeys} into bytes that represent {@link OHttpServerPublicKeys}.
      *
-     * @deprecated use {@link #encodeKeyConfigurationMediaType(ByteBuf)}
+     * @param output    the {@link ByteBuf} into which the configuration is written.
+     * @deprecated      use {@link #encodeKeyConfigurationMediaType(ByteBuf)} as this implementation does not correctly
+     *                  follow the RFC9458.
      */
     @Deprecated
     public void encodePublicKeys(ByteBuf output) {
-        encodeKeyConfigurationMediaType(output);
+        for (Map.Entry<Byte, OHttpKey.PrivateKey> key : keyMap.entrySet()) {
+            encodeKeyConfiguration(key.getKey(), key.getValue(), output);
+        }
     }
 
     /**

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerKeys.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerKeys.java
@@ -20,12 +20,14 @@ import io.netty.incubator.codec.hpke.AsymmetricCipherKeyPair;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.internal.ObjectUtil;
 
+import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
 import io.netty.incubator.codec.hpke.KEM;
+import io.netty.util.internal.PlatformDependent;
 
 /**
  * Set of key pairs and cipher suites for a OHTTP server.
@@ -84,29 +86,62 @@ public final class OHttpServerKeys {
         return keyMap.hashCode();
     }
 
-    /*
-     * Encode {@link ServerKeys} into bytes that represent {@link ServerPublicKeys}, using the format
+    /**
+     * Encode {@link OHttpServerKeys} into bytes that represent {@link OHttpServerPublicKeys}, using the format
      * described at https://ietf-wg-ohai.github.io/oblivious-http/draft-ietf-ohai-ohttp.html#section-3.1
+     *
+     * @deprecated use {@link #encodeKeyConfigurationMediaType(ByteBuf)}
      */
+    @Deprecated
     public void encodePublicKeys(ByteBuf output) {
+        encodeKeyConfigurationMediaType(output);
+    }
+
+    /**
+     * Encode a key configuration into bytes, using the format
+     * described in <a href="https://www.rfc-editor.org/rfc/rfc9458.html#section-3.1">RFC 9458 Section 3.1</a>.
+     *
+     * @param id        the id of the key.
+     * @param key       the {@link OHttpKey.PrivateKey}.
+     * @param output    the {@link ByteBuf} into which the configuration is written.
+     */
+    private static void encodeKeyConfiguration(Byte id, OHttpKey.PrivateKey key, ByteBuf output) {
+        KEM kem = key.kem();
+        AsymmetricCipherKeyPair kp = key.keyPair();
+        output.writeByte(id);
+        output.writeShort(kem.id());
+
+        byte[] encoded = kp.publicParameters().encoded();
+        if (encoded == null) {
+            throw new EncoderException("Unable to encode public keys.");
+        }
+        output.writeBytes(encoded);
+
+        // Multiple by 4 as for each cipher we will write 2 short values.
+        output.writeShort(key.ciphers().size() * 4);
+        for (OHttpKey.Cipher cipher : key.ciphers()) {
+            output.writeShort(cipher.kdf().id());
+            output.writeShort(cipher.aead().id());
+        }
+    }
+
+    /**
+     * Encode the key configurations into bytes, using the format described in
+     * <a href="https://www.rfc-editor.org/rfc/rfc9458.html#section-3.2">RFC 9458 Section 3.2</a>.
+     *
+     * @param output    the {@link ByteBuf} into which the configuration is written.
+     */
+    public void encodeKeyConfigurationMediaType(ByteBuf output) {
         for (Map.Entry<Byte, OHttpKey.PrivateKey> key : keyMap.entrySet()) {
-            KEM kem = key.getValue().kem();
-            AsymmetricCipherKeyPair kp = key.getValue().keyPair();
-            output.writeByte(key.getKey());
-            output.writeShort(kem.id());
-
-            byte[] encoded = kp.publicParameters().encoded();
-            if (encoded == null) {
-                throw new EncoderException("Unable to encode public keys.");
-            }
-            output.writeBytes(encoded);
-
-            // Multiple by 4 as for each cipher we will write 2 short values.
-            output.writeShort(key.getValue().ciphers().size() * 4);
-            for (OHttpKey.Cipher cipher : key.getValue().ciphers()) {
-                output.writeShort(cipher.kdf().id());
-                output.writeShort(cipher.aead().id());
-            }
+            int writerIndex = output.writerIndex();
+            // Skip the first two bytes as we will use these later to set the actual len that was used.
+            output.ensureWritable(2);
+            output.writerIndex(writerIndex + 2);
+            encodeKeyConfiguration(key.getKey(), key.getValue(), output);
+            int written = output.writerIndex() - writerIndex - 2;
+            // The length needs to be added in front:
+            // See https://www.rfc-editor.org/rfc/rfc9458.html#section-3.2
+            output.setShort(writerIndex, written);
         }
     }
 }

--- a/codec-ohttp/src/test/java/io/netty/incubator/codec/ohttp/OHttpCryptoTest.java
+++ b/codec-ohttp/src/test/java/io/netty/incubator/codec/ohttp/OHttpCryptoTest.java
@@ -105,13 +105,15 @@ public class OHttpCryptoTest {
 
         ByteBuf encodedKeyConfiguration = Unpooled.buffer();
         try {
-            serverKeys.encodePublicKeys(encodedKeyConfiguration);
-            assertEquals("01002031e1f05a740102115220e9af918f738674aec95f54db6e04eb705aae8e79815500080001000100010003"
-                    , ByteBufUtil.hexDump(encodedKeyConfiguration));
+            serverKeys.encodeKeyConfigurationMediaType(encodedKeyConfiguration);
+            assertEquals(
+                    "002d01002031e1f05a740102115220e9af918f738674aec95f54db6e04eb705aae8e79815500080001000100010003",
+                    ByteBufUtil.hexDump(encodedKeyConfiguration));
 
             // Key configuration decoding
 
-            OHttpServerPublicKeys clientKeys = OHttpServerPublicKeys.decode(encodedKeyConfiguration);
+            OHttpServerPublicKeys clientKeys =
+                    OHttpServerPublicKeys.decodeKeyConfigurationMediaType(encodedKeyConfiguration);
             assertEquals(1, clientKeys.keys().size());
             OHttpKey.PublicKey key = clientKeys.key(keyId);
             assertNotNull(key);


### PR DESCRIPTION
Motivation:

We didnt correctly implement encoding / decoding as we missed to prefix the length as defined in https://www.rfc-editor.org/rfc/rfc9458.html#section-3.2

Modifications:

- Add new methods and deprecate the old ones
- Correctly handle the prefix
- Adjust tests

Result:

Correctly follow https://www.rfc-editor.org/rfc/rfc9458.html#section-3.2