### PR TITLE
Ensure BoringSSLAsymmetricCipherKeyPair will eventually release nativ…

### DIFF
--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAEADContext.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAEADContext.java
@@ -63,8 +63,8 @@ final class BoringSSLAEADContext extends BoringSSLCryptoContext implements AEADC
         }
     };
 
-    BoringSSLAEADContext(BoringSSLOHttpCryptoProvider cryptoProvider, long ctx, int aeadMaxOverhead, byte[] baseNonce) {
-        super(cryptoProvider, ctx);
+    BoringSSLAEADContext(long ctx, int aeadMaxOverhead, byte[] baseNonce) {
+        super(ctx);
         this.nonce = new Nonce(baseNonce);
         this.aeadMaxOverhead = aeadMaxOverhead;
     }

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAsymmetricCipherKeyPair.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLAsymmetricCipherKeyPair.java
@@ -16,7 +16,6 @@
 package io.netty.incubator.codec.hpke.boringssl;
 
 import io.netty.incubator.codec.hpke.AsymmetricCipherKeyPair;
-import io.netty.incubator.codec.hpke.AsymmetricKeyParameter;
 
 // TODO: Maybe expose sub-type which is ReferenceCounted and so allows to take ownership of EVP_HPKE_KEY.
 final class BoringSSLAsymmetricCipherKeyPair implements AsymmetricCipherKeyPair {
@@ -76,6 +75,17 @@ final class BoringSSLAsymmetricCipherKeyPair implements AsymmetricCipherKeyPair 
                 "privateKey=" + privateKey +
                 ", publicKey=" + publicKey +
                 '}';
+    }
+
+    @Override
+    protected void finalize() throws Throwable {
+        try {
+            if (key != -1) {
+                BoringSSL.EVP_HPKE_KEY_cleanup_and_free(key);
+            }
+        } finally {
+            super.finalize();
+        }
     }
 }
 

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLCryptoContext.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLCryptoContext.java
@@ -24,13 +24,10 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 abstract class BoringSSLCryptoContext implements CryptoContext {
 
-    private final BoringSSLOHttpCryptoProvider cryptoProvider;
-
     // We use an AtomicLong to reduce the possibility of crashing after the user called close().
     private final AtomicLong ctxRef;
 
-    BoringSSLCryptoContext(BoringSSLOHttpCryptoProvider cryptoProvider, long ctx) {
-        this.cryptoProvider = cryptoProvider;
+    BoringSSLCryptoContext(long ctx) {
         assert ctx != -1;
         this.ctxRef = new AtomicLong(ctx);
     }
@@ -54,7 +51,6 @@ abstract class BoringSSLCryptoContext implements CryptoContext {
        long ctx = ctxRef.getAndSet(-1);
        if (ctx != -1) {
            destroyCtx(ctx);
-           cryptoProvider.free_EVP_HPKE_KEYS();
        }
     }
 

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKEContext.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKEContext.java
@@ -24,8 +24,8 @@ class BoringSSLHPKEContext extends BoringSSLCryptoContext implements HPKEContext
 
     private final long digest;
 
-    BoringSSLHPKEContext(BoringSSLOHttpCryptoProvider cryptoProvider, long hpkeCtx) {
-        super(cryptoProvider, hpkeCtx);
+    BoringSSLHPKEContext(long hpkeCtx) {
+        super(hpkeCtx);
         digest = BoringSSL.EVP_HPKE_KDF_hkdf_md(BoringSSL.EVP_HPKE_CTX_kdf(hpkeCtx));
     }
 

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKERecipientContext.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKERecipientContext.java
@@ -41,9 +41,9 @@ final class BoringSSLHPKERecipientContext extends BoringSSLHPKEContext implement
     // Store a reference to the keyPair here so we are sure it will only be GCed once the context is collected as well.
     final AsymmetricCipherKeyPair keyPair;
 
-    BoringSSLHPKERecipientContext(BoringSSLOHttpCryptoProvider cryptoProvider, long hpkeCtx,
+    BoringSSLHPKERecipientContext(long hpkeCtx,
                                   AsymmetricCipherKeyPair keyPair) {
-        super(cryptoProvider, hpkeCtx);
+        super(hpkeCtx);
         this.keyPair = keyPair;
     }
 

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKESenderContext.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLHPKESenderContext.java
@@ -41,8 +41,8 @@ final class BoringSSLHPKESenderContext extends BoringSSLHPKEContext
 
     private final byte[] encapsulation;
 
-    BoringSSLHPKESenderContext(BoringSSLOHttpCryptoProvider cryptoProvider, long hpkeCtx, byte[] encapsulation) {
-        super(cryptoProvider, hpkeCtx);
+    BoringSSLHPKESenderContext(long hpkeCtx, byte[] encapsulation) {
+        super(hpkeCtx);
         this.encapsulation = encapsulation;
     }
 


### PR DESCRIPTION
…e memory

Motivation:

How we tried to release native memory did not work for various reasons.

Modifications:

Ensure native memory is released

Result:

No more native memory leak causes by keypairs