### PR TITLE
Add utility class which contains methods which helps to convert HTTP1…

### DIFF
--- a/codec-bhttp/src/main/java/io/netty/incubator/codec/bhttp/BinaryHttpConverter.java
+++ b/codec-bhttp/src/main/java/io/netty/incubator/codec/bhttp/BinaryHttpConverter.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.bhttp;
+
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.AsciiString;
+
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Class which contains various methods to convert from regular HTTP1/x to
+ * <a href="https://www.rfc-editor.org/rfc/rfc9292.html">Binary Representation of HTTP Messages</a>..
+ */
+public final class BinaryHttpConverter {
+
+    private BinaryHttpConverter() { }
+
+    /**
+     * Creates a {@link BinaryHttpRequest} from the given {@link HttpRequest}, scheme and authority.
+     * All {@link HttpHeaders} names of the {@link HttpRequest} will be changed to lowercase to be in line with
+     * the
+     * <a href="https://www.rfc-editor.org/rfc/rfc9292.html">Binary Representation of HTTP Messages</a> specification.
+     *
+     * @param request   the request.
+     * @param scheme    the scheme
+     * @param authority the authority.
+     * @return          the created request.
+     */
+    public static BinaryHttpRequest convert(HttpRequest request, String scheme, String authority) {
+        if (request instanceof FullBinaryHttpRequest) {
+            return convert((FullHttpRequest) request, scheme, authority);
+        }
+        BinaryHttpHeaders headers = copyAndSanitize(request.headers());
+        return new DefaultBinaryHttpRequest(request.protocolVersion(), request.method(), scheme, authority,
+                request.uri(), headers);
+    }
+
+    /**
+     * Creates a {@link FullBinaryHttpRequest} from the given {@link FullHttpRequest}, scheme and authority.
+     * All {@link HttpHeaders} names of the {@link FullHttpRequest} will be changed to lowercase to be in line with
+     * the
+     * <a href="https://www.rfc-editor.org/rfc/rfc9292.html">Binary Representation of HTTP Messages</a> specification.
+     *
+     * @param request   the request.
+     * @param scheme    the scheme
+     * @param authority the authority.
+     * @return          the created request.
+     */
+    public static FullBinaryHttpRequest convert(FullHttpRequest request, String scheme, String authority) {
+        BinaryHttpHeaders headers = copyAndSanitize(request.headers());
+        BinaryHttpHeaders trailers = copyAndSanitize(request.trailingHeaders());
+
+        FullBinaryHttpRequest binaryHttpRequest =  new DefaultFullBinaryHttpRequest(request.protocolVersion(),
+                request.method(), scheme, authority, request.uri(), request.content().retain(), headers, trailers);
+        request.release();
+        return binaryHttpRequest;
+    }
+
+    /**
+     * Creates a {@link BinaryHttpResponse} from the given {@link HttpResponse}.
+     * All {@link HttpHeaders} names of the {@link HttpResponse} will be changed to lowercase to be in line with
+     * the
+     * <a href="https://www.rfc-editor.org/rfc/rfc9292.html">Binary Representation of HTTP Messages</a> specification.
+     *
+     * @param response  the response.
+     * @return          the created response.
+     */
+    public static BinaryHttpResponse convert(HttpResponse response) {
+        if (response instanceof FullBinaryHttpRequest) {
+            return convert((FullHttpResponse) response);
+        }
+        BinaryHttpHeaders headers = copyAndSanitize(response.headers());
+        return new DefaultBinaryHttpResponse(response.protocolVersion(), response.status(), headers);
+    }
+
+    /**
+     * Creates a {@link FullBinaryHttpResponse} from the given {@link FullHttpRequest}.
+     * All {@link HttpHeaders} names of the {@link FullHttpResponse} will be changed to lowercase to be in line with
+     * the
+     * <a href="https://www.rfc-editor.org/rfc/rfc9292.html">Binary Representation of HTTP Messages</a> specification.
+     *
+     * @param response  the response.
+     * @return          the created response.
+     */
+    public static FullBinaryHttpResponse convert(FullHttpResponse response) {
+        BinaryHttpHeaders headers = copyAndSanitize(response.headers());
+        BinaryHttpHeaders trailers = copyAndSanitize(response.trailingHeaders());
+
+        FullBinaryHttpResponse binaryHttpResponse =  new DefaultFullBinaryHttpResponse(response.protocolVersion(),
+                response.status(), response.content().retain(), headers, trailers);
+        response.release();
+        return binaryHttpResponse;
+    }
+
+    /**
+     * Creates a BHTTP compatible {@link LastHttpContent} from the given {@link LastHttpContent}.
+     * All {@link HttpHeaders} names of the {@link LastHttpContent} will be changed to lowercase to be in line with
+     * the
+     * <a href="https://www.rfc-editor.org/rfc/rfc9292.html">Binary Representation of HTTP Messages</a> specification.
+     *
+     * @param content   the last content..
+     * @return          the created content.
+     */
+    public static LastHttpContent convert(LastHttpContent content) {
+        HttpHeaders trailers = copyAndSanitize(content.trailingHeaders());
+        LastHttpContent binaryContent =  new DefaultLastHttpContent(content.content().retain(), trailers);
+        content.release();
+        return binaryContent;
+    }
+
+    private static BinaryHttpHeaders copyAndSanitize(HttpHeaders headers) {
+        BinaryHttpHeaders binaryHttpHeaders = BinaryHttpHeaders.newHeaders(true);
+        if (headers.isEmpty()) {
+            return binaryHttpHeaders;
+        }
+        for (Iterator<Map.Entry<CharSequence, CharSequence>> it = headers.iteratorCharSequence(); it.hasNext();) {
+            final Map.Entry<CharSequence, CharSequence> entry = it.next();
+            final CharSequence name = entry.getKey();
+            if (name instanceof AsciiString) {
+                // Let's just convert to lowerCase() directly if needed, otherwise
+                // this will just return the same instance.
+                binaryHttpHeaders.add(((AsciiString) name).toLowerCase(), entry.getValue());
+            } else if (name instanceof String) {
+                // Let's just convert to lowerCase() directly if needed, otherwise
+                // this will just return the same instance.
+                binaryHttpHeaders.add(((String) name).toLowerCase(), entry.getValue());
+            } else if (isAnyUpperCase(name)) {
+                // Create a lowercase AsciiString, alternative we could also have a CharSequence that lowercase stuff
+                // on the fly.
+                binaryHttpHeaders.add(new AsciiString(name).toLowerCase(), entry.getValue());
+            } else {
+                // No need to convert it as it is lowercase already.
+                binaryHttpHeaders.add(name, entry.getValue());
+            }
+        }
+        return binaryHttpHeaders;
+    }
+
+    private static boolean isAnyUpperCase(CharSequence name) {
+        int len = name.length();
+        for (int i = 0; i < len; i++) {
+            if (AsciiString.isUpperCase(name.charAt(i))) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/codec-bhttp/src/main/java/io/netty/incubator/codec/bhttp/BinaryHttpConverter.java
+++ b/codec-bhttp/src/main/java/io/netty/incubator/codec/bhttp/BinaryHttpConverter.java
@@ -51,8 +51,10 @@ public final class BinaryHttpConverter {
             return convert((FullHttpRequest) request, scheme, authority);
         }
         BinaryHttpHeaders headers = copyAndSanitize(request.headers());
-        return new DefaultBinaryHttpRequest(request.protocolVersion(), request.method(), scheme, authority,
-                request.uri(), headers);
+        DefaultBinaryHttpRequest binaryHttpRequest = new DefaultBinaryHttpRequest(request.protocolVersion(),
+                request.method(), scheme, authority, request.uri(), headers);
+        binaryHttpRequest.setDecoderResult(request.decoderResult());
+        return binaryHttpRequest;
     }
 
     /**
@@ -72,6 +74,7 @@ public final class BinaryHttpConverter {
 
         FullBinaryHttpRequest binaryHttpRequest =  new DefaultFullBinaryHttpRequest(request.protocolVersion(),
                 request.method(), scheme, authority, request.uri(), request.content().retain(), headers, trailers);
+        binaryHttpRequest.setDecoderResult(request.decoderResult());
         request.release();
         return binaryHttpRequest;
     }
@@ -90,7 +93,10 @@ public final class BinaryHttpConverter {
             return convert((FullHttpResponse) response);
         }
         BinaryHttpHeaders headers = copyAndSanitize(response.headers());
-        return new DefaultBinaryHttpResponse(response.protocolVersion(), response.status(), headers);
+        BinaryHttpResponse binaryHttpResponse = new DefaultBinaryHttpResponse(
+                response.protocolVersion(), response.status(), headers);
+        binaryHttpResponse.setDecoderResult(response.decoderResult());
+        return binaryHttpResponse;
     }
 
     /**
@@ -108,6 +114,7 @@ public final class BinaryHttpConverter {
 
         FullBinaryHttpResponse binaryHttpResponse =  new DefaultFullBinaryHttpResponse(response.protocolVersion(),
                 response.status(), response.content().retain(), headers, trailers);
+        binaryHttpResponse.setDecoderResult(response.decoderResult());
         response.release();
         return binaryHttpResponse;
     }

--- a/codec-bhttp/src/main/java/io/netty/incubator/codec/bhttp/BinaryHttpHeaders.java
+++ b/codec-bhttp/src/main/java/io/netty/incubator/codec/bhttp/BinaryHttpHeaders.java
@@ -18,6 +18,7 @@ package io.netty.incubator.codec.bhttp;
 import io.netty.handler.codec.DefaultHeaders;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaderValidationUtil;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.util.AsciiString;
 import io.netty.util.ByteProcessor;
 
@@ -107,7 +108,17 @@ final class BinaryHttpHeaders extends DefaultHttpHeaders {
     private static final DefaultHeaders.NameValidator<CharSequence> BINARY_HTTP_TRAILERS_VALIDATOR =
             new BinaryHttpNameValidator(true);
 
+    private final boolean validate;
+    private final DefaultHeaders.NameValidator<CharSequence> validator;
+
     private BinaryHttpHeaders(boolean validate, DefaultHeaders.NameValidator<CharSequence> validator) {
         super(validate, validator);
+        this.validate = validate;
+        this.validator = validator;
+    }
+
+    @Override
+    public HttpHeaders copy() {
+        return (new BinaryHttpHeaders(validate, validator)).set(this);
     }
 }

--- a/codec-bhttp/src/main/java/io/netty/incubator/codec/bhttp/DefaultBinaryHttpResponse.java
+++ b/codec-bhttp/src/main/java/io/netty/incubator/codec/bhttp/DefaultBinaryHttpResponse.java
@@ -25,11 +25,11 @@ import io.netty.handler.codec.http.HttpVersion;
  */
 public final class DefaultBinaryHttpResponse extends DefaultHttpResponse implements BinaryHttpResponse {
     public DefaultBinaryHttpResponse(HttpVersion version, HttpResponseStatus status) {
-        super(version, status, BinaryHttpHeaders.newHeaders(true));
+        this(version, status, BinaryHttpHeaders.newHeaders(true));
     }
 
     public DefaultBinaryHttpResponse(HttpVersion version, HttpResponseStatus status, boolean validateHeaders) {
-        super(version, status, BinaryHttpHeaders.newHeaders(validateHeaders));
+        this(version, status, BinaryHttpHeaders.newHeaders(validateHeaders));
     }
 
     DefaultBinaryHttpResponse(HttpVersion version, HttpResponseStatus status, BinaryHttpHeaders headers) {

--- a/codec-bhttp/src/main/java/io/netty/incubator/codec/bhttp/DefaultFullBinaryHttpRequest.java
+++ b/codec-bhttp/src/main/java/io/netty/incubator/codec/bhttp/DefaultFullBinaryHttpRequest.java
@@ -18,7 +18,6 @@ package io.netty.incubator.codec.bhttp;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
-import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
 
@@ -86,11 +85,12 @@ public final class DefaultFullBinaryHttpRequest extends DefaultFullHttpRequest i
      * @param scheme            the scheme to use.
      * @param authority         the authority to use.
      * @param uri               the uri / path to use
-     * @param headers           the {@link HttpHeaders} of the request.
+     * @param headers           the {@link BinaryHttpHeaders} of the request.
      * @param trailingHeader    the trailers of the request.
      */
-    private DefaultFullBinaryHttpRequest(HttpVersion httpVersion, HttpMethod method, String scheme, String authority,
-                                        String uri, ByteBuf content, HttpHeaders headers, HttpHeaders trailingHeader) {
+    DefaultFullBinaryHttpRequest(HttpVersion httpVersion, HttpMethod method, String scheme, String authority,
+                                 String uri, ByteBuf content, BinaryHttpHeaders headers,
+                                 BinaryHttpHeaders trailingHeader) {
         super(httpVersion, method, uri, content, headers, trailingHeader);
         this.scheme = Objects.requireNonNull(scheme, "scheme");
         this.authority = authority;
@@ -155,7 +155,7 @@ public final class DefaultFullBinaryHttpRequest extends DefaultFullHttpRequest i
     public FullBinaryHttpRequest replace(ByteBuf content) {
         FullBinaryHttpRequest request = new DefaultFullBinaryHttpRequest(
                 protocolVersion(), method(), scheme(), authority(), uri(), content,
-                headers().copy(), trailingHeaders().copy());
+                (BinaryHttpHeaders) headers().copy(), (BinaryHttpHeaders) trailingHeaders().copy());
         request.setDecoderResult(this.decoderResult());
         return request;
     }

--- a/codec-bhttp/src/main/java/io/netty/incubator/codec/bhttp/DefaultFullBinaryHttpResponse.java
+++ b/codec-bhttp/src/main/java/io/netty/incubator/codec/bhttp/DefaultFullBinaryHttpResponse.java
@@ -46,7 +46,7 @@ public final class DefaultFullBinaryHttpResponse extends DefaultFullHttpResponse
                 BinaryHttpHeaders.newTrailers(validateHeaders));
     }
 
-    private DefaultFullBinaryHttpResponse(HttpVersion version, HttpResponseStatus status, ByteBuf content,
+    DefaultFullBinaryHttpResponse(HttpVersion version, HttpResponseStatus status, ByteBuf content,
                                   HttpHeaders headers, HttpHeaders trailingHeaders) {
         super(version, status, content, headers, trailingHeaders);
     }

--- a/codec-bhttp/src/test/java/io/netty/incubator/codec/bhttp/BinaryHttpConverterTest.java
+++ b/codec-bhttp/src/test/java/io/netty/incubator/codec/bhttp/BinaryHttpConverterTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.bhttp;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.AsciiString;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class BinaryHttpConverterTest {
+
+    private static final String URI = "/somewhere";
+    private static final String SCHEME = "https";
+    private static final String AUTHORITY = "someone@something";
+
+    @Test
+    void testConvertResponse() {
+        HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        response.headers().set(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_XHTML);
+        response.headers().set("SomeHeader", "someValue");
+        BinaryHttpResponse converted = BinaryHttpConverter.convert(response);
+        assertEquals(HttpVersion.HTTP_1_1, converted.protocolVersion());
+        assertEquals(HttpResponseStatus.OK, converted.status());
+        assertEquals(response.decoderResult(), converted.decoderResult());
+
+        assertHeaders(response.headers(), converted.headers());
+    }
+
+    @Test
+    void testConvertFullResponse() {
+        ByteBuf buffer = Unpooled.buffer().writeLong(1);
+        FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, buffer);
+        response.headers().set(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_XHTML);
+        response.headers().set("SomeHeader", "someValue");
+        response.trailingHeaders().set("SomeHeader", "someValue");
+
+        FullBinaryHttpResponse converted = BinaryHttpConverter.convert(response);
+        assertEquals(HttpVersion.HTTP_1_1, converted.protocolVersion());
+        assertEquals(HttpResponseStatus.OK, converted.status());
+        assertEquals(response.decoderResult(), converted.decoderResult());
+        assertEquals(buffer, converted.content());
+
+        assertHeaders(response.headers(), converted.headers());
+        assertHeaders(response.trailingHeaders(), converted.trailingHeaders());
+    }
+
+    @Test
+    void testConvertRequest() {
+        HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, URI);
+        request.headers().set(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_XHTML);
+        request.headers().set("SomeHeader", "someValue");
+        BinaryHttpRequest converted = BinaryHttpConverter.convert(request, SCHEME, AUTHORITY);
+        assertEquals(HttpVersion.HTTP_1_1, converted.protocolVersion());
+        assertEquals(HttpMethod.GET, converted.method());
+        assertEquals(URI, converted.uri());
+        assertEquals(SCHEME, converted.scheme());
+        assertEquals(AUTHORITY, converted.authority());
+        assertEquals(request.decoderResult(), converted.decoderResult());
+
+        assertHeaders(request.headers(), converted.headers());
+    }
+
+    @Test
+    void testConvertFullRequest() {
+        ByteBuf buffer = Unpooled.buffer().writeLong(1);
+        FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, URI, buffer);
+        request.headers().set(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_XHTML);
+        request.headers().set("SomeHeader", "someValue");
+        request.trailingHeaders().set("SomeHeader", "someValue");
+
+        FullBinaryHttpRequest converted = BinaryHttpConverter.convert(request, SCHEME, AUTHORITY);
+        assertEquals(HttpVersion.HTTP_1_1, converted.protocolVersion());
+        assertEquals(HttpMethod.GET, converted.method());
+        assertEquals(URI, converted.uri());
+        assertEquals(SCHEME, converted.scheme());
+        assertEquals(AUTHORITY, converted.authority());
+        assertEquals(request.decoderResult(), converted.decoderResult());
+        assertEquals(buffer, converted.content());
+
+        assertHeaders(request.headers(), converted.headers());
+        assertHeaders(request.trailingHeaders(), converted.trailingHeaders());
+        converted.release();
+    }
+
+    private static void assertHeaders(HttpHeaders headers, HttpHeaders binaryHeaders) {
+        for (Iterator<Map.Entry<CharSequence, CharSequence>> it = binaryHeaders.iteratorCharSequence(); it.hasNext();) {
+            Map.Entry<CharSequence, CharSequence> entry = it.next();
+            CharSequence name = entry.getKey();
+            for (int i = 0; i < name.length(); i++) {
+                assertFalse(AsciiString.isUpperCase(name.charAt(i)));
+            }
+            assertEquals(headers.get(name), entry.getValue().toString());
+        }
+    }
+}


### PR DESCRIPTION
…/x to BHTTP messages.

Motivation:

Often people need to translate from HTTP1/x to BHTTP, we should provide utilities for this.

Modifications:

Add BinaryHttpConvert class which contain various static helper methods

Result:

Easily be able to convert from HTTP1/x to BHTTP.