### PR TITLE
Ensure we will call read() if nothing was decoded and AUTO_READ is no…

### DIFF
--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpClientCodec.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpClientCodec.java
@@ -201,6 +201,7 @@ public final class OHttpClientCodec extends MessageToMessageCodec<HttpObject, Ht
         if (destroyed) {
             throw new IllegalStateException("Already destroyed");
         }
+        decodeCalled = true;
         try {
             assert !contextHolders.isEmpty();
             OHttpRequestResponseContext ohttpContext = contextHolders.peekFirst().handler;
@@ -235,6 +236,8 @@ public final class OHttpClientCodec extends MessageToMessageCodec<HttpObject, Ht
             }
         } catch (CryptoException e) {
             throw new OHttpDecoderException("failed to decrypt bytes", e);
+        } finally {
+            producedMessage |= !out.isEmpty();
         }
     }
 

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
@@ -169,7 +169,7 @@ public class OHttpServerCodec extends MessageToMessageCodec<HttpObject, HttpObje
         } catch (Exception e) {
             throw new OHttpServerDecoderException("failed to decode bytes", e);
         } finally {
-            producedMessage = !out.isEmpty();
+            producedMessage |= !out.isEmpty();
         }
     }
 

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
@@ -66,6 +66,8 @@ public class OHttpServerCodec extends MessageToMessageCodec<HttpObject, HttpObje
     private boolean sentResponse;
     private OHttpServerRequestResponseContext oHttpContext;
     private ByteBuf cumulationBuffer = Unpooled.EMPTY_BUFFER;
+    private boolean decodeCalled;
+    private boolean producedMessage;
     private boolean destroyed;
 
     public OHttpServerCodec(OHttpCryptoProvider provider, OHttpServerKeys serverKeys) {
@@ -110,6 +112,7 @@ public class OHttpServerCodec extends MessageToMessageCodec<HttpObject, HttpObje
         if (destroyed) {
             throw new IllegalStateException("Already destroyed");
         }
+        decodeCalled = true;
         try {
             if (msg instanceof HttpRequest) {
                 HttpRequest req = (HttpRequest) msg;
@@ -165,7 +168,19 @@ public class OHttpServerCodec extends MessageToMessageCodec<HttpObject, HttpObje
             }
         } catch (Exception e) {
             throw new OHttpServerDecoderException("failed to decode bytes", e);
+        } finally {
+            producedMessage = !out.isEmpty();
         }
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+        if (decodeCalled && !producedMessage && !ctx.channel().config().isAutoRead()) {
+            ctx.read();
+        }
+        decodeCalled = false;
+        producedMessage = false;
+        ctx.fireChannelReadComplete();
     }
 
     @Override


### PR DESCRIPTION
…t used

Motivation:

We should ensure we call `ctx.read()` if the codec received a message to decode but did not produce anything and AUTO_READ is set to false. Failing to do so might result in stales as the user will not know that more reads are needed to make progress. This is inline with what ByteToMessageDecoder does under the hood

Modifications:

- Change OHttpClientCodec and OHttpServerCodec to issue reads to make progress
- Add unit test

Result:

Ensure reads are submitted when needed and so no stales happen