### PR TITLE
Update to netty 4.1.114.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <javaModuleName />
     <skipTests>false</skipTests>
     <packaging.type>jar</packaging.type>
-    <netty.version>4.1.112.Final</netty.version>
+    <netty.version>4.1.114.Final</netty.version>
     <netty.build.version>31</netty.build.version>
     <netty.jni-util.version>0.0.9.Final</netty.jni-util.version>
     <junit.version>5.9.0</junit.version>


### PR DESCRIPTION
Motivation:

We should use the latest netty version as dependency

Modifications:

Update to 4.1.114.Final

Result:

Use latest netty version