### PR TITLE
Use main branch for BoringSSL

### DIFF
--- a/codec-ohttp-hpke-native-boringssl/pom.xml
+++ b/codec-ohttp-hpke-native-boringssl/pom.xml
@@ -47,7 +47,7 @@
         <boringsslHomeIncludeDir>${boringsslHomeDir}/include</boringsslHomeIncludeDir>
         <boringsslRepository>https://boringssl.googlesource.com/boringssl</boringsslRepository>
         <!-- Lets use what we use in netty-tcnative-boringssl-static -->
-        <boringsslBranch>master</boringsslBranch>
+        <boringsslBranch>main</boringsslBranch>
         <boringsslCommitSha>b8c97f5b4bc5d4758612a0430e5c2792d0f9ca7f</boringsslCommitSha>
 
         <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>


### PR DESCRIPTION
Motivation:

BoringSSL does not have a master branch anymore, switch to main

Modifications:

Switch to main branch

Result:

Project builds again