### PR TITLE
Add macos to CI

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -80,10 +80,60 @@ jobs:
           if-no-files-found: error
           include-hidden-files: true
 
+
+  stage-snapshot-macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - setup: macos-x86_64
+            os: macos-13
+          - setup: macos-aarch64
+            os: macos-15
+
+    runs-on: ${{ matrix.os }}
+    name:  ${{ matrix.setup }}  build
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+
+      # Cache .m2/repository
+      # Caching of maven dependencies
+      - uses: actions/cache@v4
+        continue-on-error: true
+        with:
+          path: ~/.m2/repository
+          key: pr-${{ matrix.setup }}-maven-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            pr-${{ matrix.setup }}-maven-cache-
+
+      - name: Install tools via brew
+        run: brew bundle
+
+      - name: Create local staging directory
+        run: mkdir -p ~/local-staging
+
+      - name: Stage snapshots to local staging directory
+        run: ./mvnw -B -ntp clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=$HOME/local-staging -DskipRemoteStaging=true -DskipTests=true
+
+      - name: Upload local staging directory
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.setup }}-local-staging
+          path: ~/local-staging
+          if-no-files-found: error
+          include-hidden-files: true
+
   deploy-staged-snapshots:
     runs-on: ubuntu-latest
     # Wait until we have staged everything
-    needs: [stage-snapshot-linux]
+    needs: [stage-snapshot-linux, stage-snapshot-macos]
     steps:
       - uses: actions/checkout@v4
 
@@ -92,6 +142,15 @@ jobs:
         with:
           distribution: zulu
           java-version: 8
+
+      - uses: s4u/maven-settings-action@v3.0.0
+        with:
+          servers: |
+            [{
+              "id": "sonatype-nexus-snapshots",
+              "username": "${{ secrets.SONATYPE_USERNAME }}",
+              "password": "${{ secrets.SONATYPE_PASSWORD }}"
+            }]
 
       # Caching of maven dependencies
       - uses: actions/cache@v4
@@ -109,6 +168,19 @@ jobs:
 
       # Hardcode the staging artifacts that need to be downloaded.
       # These must match the matrix setups and windows build. There is currently no way to pull this out of the config.
+
+      - name: Download macos-x86_64 staging directory
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-x86_64-local-staging
+          path: ~/macos-x86_64-local-staging
+
+      - name: Download macos-aarch64 staging directory
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-aarch64-local-staging
+          path: ~/macos-aarch64-local-staging
+
       - name: Download linux-aarch64 staging directory
         uses: actions/download-artifact@v4
         with:
@@ -122,16 +194,7 @@ jobs:
           path: ~/linux-x86_64-local-staging
 
       - name: Merge staging repositories
-        run: bash ./.github/scripts/merge_local_staging.sh ~/local-staging ~/linux-aarch64-local-staging ~/linux-x86_64-local-staging
-
-      - uses: s4u/maven-settings-action@v3.0.0
-        with:
-          servers: |
-            [{
-              "id": "sonatype-nexus-snapshots",
-              "username": "${{ secrets.SONATYPE_USERNAME }}",
-              "password": "${{ secrets.SONATYPE_PASSWORD }}"
-            }]
+        run: bash ./.github/scripts/merge_local_staging.sh ~/local-staging ~/macos-x86_64-local-staging ~/macos-aarch64-local-staging ~/linux-aarch64-local-staging ~/linux-x86_64-local-staging
 
       - name: Deploy local staged artifacts
         run: ./mvnw -B -ntp --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DaltStagingDirectory=$LOCAL_STAGING_DIR

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -97,3 +97,56 @@ jobs:
             **/target/surefire-reports/
             **/hs_err*.log
             **/core.*
+
+  build-pr-macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - setup: macos-x86_64-java8
+            os: macos-13
+          - setup: macos-aarch64-java8
+            os: macos-15
+
+    runs-on: ${{ matrix.os }}
+    name:  ${{ matrix.setup }}  build
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+
+      # Cache .m2/repository
+      # Caching of maven dependencies
+      - uses: actions/cache@v4
+        continue-on-error: true
+        with:
+          path: ~/.m2/repository
+          key: pr-${{ matrix.setup }}-maven-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            pr-${{ matrix.setup }}-maven-cache-
+
+      - name: Install tools via brew
+        run: brew bundle
+
+      - name: Build project
+        run: ./mvnw -B -ntp --file pom.xml clean package -DskipTests=true
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.setup }}
+          path: '**/target/surefire-reports/TEST-*.xml'
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
+        with:
+          name: build-pr-${{ matrix.setup }}-target
+          path: |
+            **/target/surefire-reports/
+            **/hs_err*.log


### PR DESCRIPTION
Motivation:

We can also build and deploy artifacts for macos.

Modifications:

Add github workflow config to also include macos

Result:

Automatically build and deploy for macos