### PR TITLE
Add macos artifacts as part of the release workflow

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -160,10 +160,101 @@ jobs:
         # Rollback the release in case of an failure
         run: bash ./.github/scripts/release_rollback.sh release.properties netty/netty-incubator-codec-ohttp main
 
+  stage-release-macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - setup: macos-x86_64
+            os: macos-13
+          - setup: macos-aarch64
+            os: macos-15
+    needs: prepare-release
+    runs-on: ${{ matrix.os }}
+    name:  stage-release-${{ matrix.setup }}
+
+    steps:
+      - name: Download release-workspace
+        uses: actions/download-artifact@v4
+        with:
+          name: prepare-release-workspace
+          path: ./prepare-release-workspace/
+
+      - name: Adjust mvnw permissions
+        run: chmod 755 ./prepare-release-workspace/mvnw
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Setup git configuration
+        run: |
+          git config --global user.email "netty-project-bot@users.noreply.github.com"
+          git config --global user.name "Netty Project Bot"
+
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_PRIVATE_KEY_PEM }}
+          known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
+
+      - uses: s4u/maven-settings-action@v3.0.0
+        with:
+          servers: |
+            [{
+              "id": "sonatype-nexus-staging",
+              "username": "${{ secrets.SONATYPE_USERNAME }}",
+              "password": "${{ secrets.SONATYPE_PASSWORD }}"
+            }]
+
+      # Cache .m2/repository
+      # Caching of maven dependencies
+      - uses: actions/cache@v4
+        continue-on-error: true
+        with:
+          path: ~/.m2/repository
+          key: pr-${{ matrix.setup }}-maven-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            pr-${{ matrix.setup }}-maven-cache-
+
+      - name: Install tools via brew
+        working-directory: ./prepare-release-workspace/
+        run: brew bundle
+
+      - name: Create local staging directory
+        run: mkdir -p ~/local-staging
+
+      - name: Stage snapshots to local staging directory
+        working-directory: ./prepare-release-workspace/
+        run: ./mvnw -B -ntp clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=$HOME/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }} -Dgpg.keyname=${{ secrets.GPG_KEYNAME }}
+
+      - name: Upload local staging directory
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.setup }}-local-staging
+          path: ~/local-staging
+          if-no-files-found: error
+          include-hidden-files: true
+
+      - name: Rollback release on failure
+        working-directory: ./prepare-release-workspace/
+        if: ${{ failure() }}
+        # Rollback the release in case of an failure
+        run: bash ./.github/scripts/release_rollback.sh release.properties netty/netty-incubator-codec-ohttp main
+
   deploy-staged-release:
     runs-on: ubuntu-latest
     # Wait until we have staged everything
-    needs: [stage-release-linux]
+    needs: [stage-release-linux, stage-release-macos]
     steps:
       - name: Download release-workspace
         uses: actions/download-artifact@v4
@@ -193,6 +284,18 @@ jobs:
 
       # Hardcode the staging artifacts that need to be downloaded.
       # These must match the matrix setups. There is currently no way to pull this out of the config.
+      - name: Download macos-x86_64 staging directory
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-x86_64-local-staging
+          path: ~/macos-x86_64-local-staging
+
+      - name: Download macos-aarch64 staging directory
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-aarch64-local-staging
+          path: ~/macos-aarch64-local-staging
+
       - name: Download linux-aarch64 staging directory
         uses: actions/download-artifact@v4
         with:
@@ -209,7 +312,7 @@ jobs:
       # all together with one maven command.
       - name: Merge staging repositories
         working-directory: ./prepare-release-workspace/
-        run: bash ./.github/scripts/merge_local_staging.sh /home/runner/local-staging/staging ~/linux-aarch64-local-staging/staging ~/linux-x86_64-local-staging/staging
+        run: bash ./.github/scripts/merge_local_staging.sh ~/local-staging/staging ~/macos-x86_64-local-staging/staging ~/macos-aarch64-local-staging/staging ~/linux-aarch64-local-staging/staging ~/linux-x86_64-local-staging/staging
 
       # Caching of maven dependencies
       - uses: actions/cache@v4
@@ -232,7 +335,7 @@ jobs:
       - name: Deploy local staged artifacts
         working-directory: ./prepare-release-workspace/
         # If we don't want to close the repository we can add -DskipStagingRepositoryClose=true
-        run: ./mvnw -B -ntp --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/home/runner/local-staging -DskipStagingRepositoryClose=true
+        run: ./mvnw -B -ntp --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=$HOME/local-staging -DskipStagingRepositoryClose=true
 
       - name: Rollback release on failure
         working-directory: ./prepare-release-workspace/


### PR DESCRIPTION
Motivation:

We can fully automate the release process by also building, stating and deploying macos artifacts.

Modifications:

Adjust workflow to also handle artifacts for macos

Result:

Fully automated release process