### PR TITLE
Migrate to using maven central for release

### DIFF
--- a/.github/scripts/bundle_create.sh
+++ b/.github/scripts/bundle_create.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# ----------------------------------------------------------------------------
+# Copyright 2025 The Netty Project
+#
+# The Netty Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+set -e
+
+if [ "$#" -ne 2 ]; then
+    echo "Expected bundle name and directory"
+    exit 1
+fi
+
+pushd $2
+zip -r $1 * -x maven-metadata-central-staging.xml
+popd

--- a/.github/scripts/bundle_upload.sh
+++ b/.github/scripts/bundle_upload.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# ----------------------------------------------------------------------------
+# Copyright 2025 The Netty Project
+#
+# The Netty Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+set -e
+
+if [ "$#" -ne 3 ]; then
+    echo "Expected bundle name"
+    exit 1
+fi
+
+BEARER=`printf "$2:$3" | base64`
+
+ curl --request POST \
+  --header "Authorization: Bearer $BEARER" \
+  --form bundle=@$1 \
+  https://central.sonatype.com/api/v1/publisher/upload

--- a/.github/scripts/local_staging_merge_release.sh
+++ b/.github/scripts/local_staging_merge_release.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# ----------------------------------------------------------------------------
+# Copyright 2025 The Netty Project
+#
+# The Netty Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+set -e
+if [ "$#" -lt 2 ]; then
+    echo "Expected target directory and at least one local staging directory"
+    exit 1
+fi
+TARGET=$1
+
+for ((i=2; i<=$#; i++))
+do
+  DIR="${!i}"
+
+  if [ ! -d "${TARGET}" ]
+  then
+      mkdir -p "${TARGET}"
+  fi
+  cp -r "${DIR}"/"${SUB_DIR}"/* "${TARGET}/${SUB_DIR}"/
+done

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -128,9 +128,9 @@ jobs:
         with:
           servers: |
             [{
-              "id": "sonatype-nexus-staging",
-              "username": "${{ secrets.SONATYPE_USERNAME }}",
-              "password": "${{ secrets.SONATYPE_PASSWORD }}"
+              "id": "central",
+              "username": "${{ secrets.MAVEN_CENTRAL_USERNAME }}",
+              "password": "${{ secrets.MAVEN_CENTRAL_PASSWORD }}"
             }]
 
       - name: Create local staging directory
@@ -152,7 +152,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.setup }}-local-staging
-          path: ~/local-staging
+          path: target/central-deferred
           if-no-files-found: error
           include-hidden-files: true
 
@@ -213,10 +213,11 @@ jobs:
         with:
           servers: |
             [{
-              "id": "sonatype-nexus-staging",
-              "username": "${{ secrets.SONATYPE_USERNAME }}",
-              "password": "${{ secrets.SONATYPE_PASSWORD }}"
+              "id": "central",
+              "username": "${{ secrets.MAVEN_CENTRAL_USERNAME }}",
+              "password": "${{ secrets.MAVEN_CENTRAL_PASSWORD }}"
             }]
+
 
       # Cache .m2/repository
       # Caching of maven dependencies
@@ -232,18 +233,15 @@ jobs:
         working-directory: ./prepare-release-workspace/
         run: brew bundle
 
-      - name: Create local staging directory
-        run: mkdir -p ~/local-staging
-
       - name: Stage snapshots to local staging directory
         working-directory: ./prepare-release-workspace/
-        run: ./mvnw -B -ntp clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=$HOME/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }} -Dgpg.keyname=${{ secrets.GPG_KEYNAME }}
+        run: ./mvnw -B -ntp clean package javadoc:jar gpg:sign org.sonatype.central:central-publishing-maven-plugin:publish -DskipTests=true
 
       - name: Upload local staging directory
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.setup }}-local-staging
-          path: ~/local-staging
+          path: target/central-deferred
           if-no-files-found: error
           include-hidden-files: true
 
@@ -314,34 +312,16 @@ jobs:
       # all together with one maven command.
       - name: Merge staging repositories
         working-directory: ./prepare-release-workspace/
-        run: bash ./.github/scripts/merge_local_staging.sh ~/local-staging/staging ~/macos-x86_64-local-staging/staging ~/macos-aarch64-local-staging/staging ~/linux-aarch64-local-staging/staging ~/linux-x86_64-local-staging/staging
+        run: bash ./.github/scripts/local_staging_marge_release.sh ~/local-staging ~/macos-x86_64-local-staging ~/macos-aarch64-local-staging ~/linux-aarch64-local-staging ~/linux-x86_64-local-staging
 
-      # Caching of maven dependencies
-      - uses: actions/cache@v4
-        continue-on-error: true
-        with:
-          path: ~/.m2/repository
-          key: deploy-staged-release-maven-cache-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            deploy-staged-release-maven-cache-
+      - name: Create bundle
+        run: bash ./.github/scripts/bundle_create.sh ~/central-bundle.zip ~/local-staging/
 
-      - uses: s4u/maven-settings-action@v3.0.0
-        with:
-          servers: |
-            [{
-              "id": "sonatype-nexus-staging",
-              "username": "${{ secrets.SONATYPE_USERNAME }}",
-              "password": "${{ secrets.SONATYPE_PASSWORD }}"
-            }]
-
-      - name: Deploy local staged artifacts
-        working-directory: ./prepare-release-workspace/
-        # If we don't want to close the repository we can add -DskipStagingRepositoryClose=true
-        run: ./mvnw -B -ntp --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=$HOME/local-staging -DskipStagingRepositoryClose=true
+      - name: Upload bundle to maven central
+        run: bash ./.github/scripts/bundle_upload.sh ~/central-bundle.zip ${{ secrets.MAVEN_CENTRAL_USERNAME }} ${{ secrets.MAVEN_CENTRAL_PASSWORD }
 
       - name: Rollback release on failure
         working-directory: ./prepare-release-workspace/
         if: ${{ failure() }}
         # Rollback the release in case of an failure
         run: bash ./.github/scripts/release_rollback.sh release.properties netty/netty-incubator-codec-ohttp main
-

--- a/docker/docker-compose.centos-7-cross.yaml
+++ b/docker/docker-compose.centos-7-cross.yaml
@@ -68,7 +68,7 @@ services:
       - ~/.m2/repository:/root/.m2/repository
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -ntp -Plinux-aarch64 clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
+    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -ntp -Plinux-aarch64 clean package javadoc:jar gpg:sign org.sonatype.central:central-publishing-maven-plugin:publish -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
 
   cross-compile-aarch64-install:
     <<: *cross-compile-aarch64-common

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -78,7 +78,7 @@ services:
       - ~/.m2/repository:/root/.m2/repository
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -ntp clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
+    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -ntp clean package javadoc:jar gpg:sign org.sonatype.central:central-publishing-maven-plugin:publish -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
 
   shell:
     <<: *common

--- a/pom.xml
+++ b/pom.xml
@@ -373,6 +373,16 @@
           </dependency>
         </dependencies>
       </plugin>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.7.0</version>
+        <configuration>
+          <publishingServerId>central</publishingServerId>
+          <skipPublishing>true</skipPublishing>
+          <autoPublish>false</autoPublish>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Motivation:

OSSRH is deprecated and will be shut down soon. Let's switch to using maven central

Modifications:

- Replace old plugin with central-publishing-maven-plugin
- Adjust workflow to setup the right token / password

Result:

Release works again