### PR TITLE
Update jni-util version to clarify licensing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <packaging.type>jar</packaging.type>
     <netty.version>4.1.127.Final</netty.version>
     <netty.build.version>31</netty.build.version>
-    <netty.jni-util.version>0.0.9.Final</netty.jni-util.version>
+    <netty.jni-util.version>0.0.10.Final</netty.jni-util.version>
     <junit.version>5.9.0</junit.version>
     <test.argLine>-D_</test.argLine>
     <bundleNativeCode />


### PR DESCRIPTION
Motivation:

A new jni-util version was released which replaced some code which had no clear licensing.

Modifications:

Upgrade to latest version

Result:

Clear licensing of jni-util dependency