### PR TITLE
Update to run-on-arch-action@v3

### DIFF
--- a/.github/workflows/ci-verify-load.yml
+++ b/.github/workflows/ci-verify-load.yml
@@ -76,7 +76,7 @@ jobs:
           name:  maven-repository
           path: /home/runner/jars
 
-      - uses: uraimo/run-on-arch-action@v2
+      - uses: uraimo/run-on-arch-action@v3
         name: Check native loading
         id: runcmd
         with:


### PR DESCRIPTION
Motivation:

A new version of run-on-arch-action was released that fixes segmentation fault which we also sometimes observed

Modifications:

- Update to v3

Result:

Hopefully no more faults during workflow run