### PR TITLE
Use ChannelHandler as return type

### DIFF
--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpClientCodecBuilder.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpClientCodecBuilder.java
@@ -15,6 +15,7 @@
  */
 package io.netty.incubator.codec.ohttp;
 
+import io.netty.channel.ChannelHandler;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.incubator.codec.hpke.OHttpCryptoProvider;
 
@@ -23,7 +24,7 @@ import java.util.function.Function;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Configuration for the {@link OHttpClientCodec}.
+ * Builder for the {@link OHttpClientCodec}.
  * The following settings are mandatory to configure:
  * <ul>
  *     <li>{@link #setProvider(OHttpCryptoProvider)}</li>
@@ -41,7 +42,6 @@ public final class OHttpClientCodecBuilder extends OHttpCodecBuilder<OHttpClient
      *     <li>{@link OHttpClientCodecBuilder#setProvider(OHttpCryptoProvider)}</li>
      *     <li>{@link OHttpClientCodecBuilder#setEncapsulationFunction(Function)}</li>
      * </ul>
-     * @return a new {@link OHttpClientCodecBuilder} builder instance.
      */
     public OHttpClientCodecBuilder() {
     }
@@ -72,7 +72,7 @@ public final class OHttpClientCodecBuilder extends OHttpCodecBuilder<OHttpClient
     }
 
     @Override
-    public OHttpClientCodec build() {
+    public ChannelHandler build() {
         return new OHttpClientCodec(this);
     }
 }

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCodecBuilder.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCodecBuilder.java
@@ -15,8 +15,7 @@
  */
 package io.netty.incubator.codec.ohttp;
 
-import io.netty.handler.codec.MessageToMessageCodec;
-import io.netty.handler.codec.http.HttpObject;
+import io.netty.channel.ChannelHandler;
 import io.netty.incubator.codec.hpke.OHttpCryptoProvider;
 
 import static java.util.Objects.requireNonNull;
@@ -99,5 +98,5 @@ public abstract class OHttpCodecBuilder<B extends OHttpCodecBuilder<B>> implemen
      * Build the configured codec.
      * @return A new codec instance.
      */
-    public abstract MessageToMessageCodec<HttpObject, HttpObject> build();
+    public abstract ChannelHandler build();
 }

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodecBuilder.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodecBuilder.java
@@ -15,12 +15,13 @@
  */
 package io.netty.incubator.codec.ohttp;
 
+import io.netty.channel.ChannelHandler;
 import io.netty.incubator.codec.hpke.OHttpCryptoProvider;
 
 import static java.util.Objects.requireNonNull;
 
 /**
- * Configuration for the {@link OHttpServerCodec}.
+ * Builder for the {@link OHttpServerCodec}.
  * The following settings are mandatory to configure:
  * <ul>
  *     <li>{@link #setProvider(OHttpCryptoProvider)}</li>
@@ -38,7 +39,6 @@ public final class OHttpServerCodecBuilder extends OHttpCodecBuilder<OHttpServer
      *     <li>{@link OHttpServerCodecBuilder#setProvider(OHttpCryptoProvider)}</li>
      *     <li>{@link OHttpServerCodecBuilder#setServerKeys(OHttpServerKeys)}</li>
      * </ul>
-     * @return a new {@link OHttpServerCodecBuilder} builder instance.
      */
     public OHttpServerCodecBuilder() {
     }
@@ -64,7 +64,7 @@ public final class OHttpServerCodecBuilder extends OHttpCodecBuilder<OHttpServer
     }
 
     @Override
-    public OHttpServerCodec build() {
+    public ChannelHandler build() {
         return new OHttpServerCodec(this);
     }
 }


### PR DESCRIPTION
Motivation:

There is no need to restrict the returned codec to be a MessageToMessageCodec.

Modifications:

Use ChannelHandler as return type

Result:

More flexibility later on