### PR TITLE
If EVP_HPKE_CTX_export fails it might cause UB and so a crash

### DIFF
--- a/codec-ohttp-hpke-native-boringssl/src/main/c/netty_incubator_codec_ohttp_hpke_boringssl.c
+++ b/codec-ohttp-hpke-native-boringssl/src/main/c/netty_incubator_codec_ohttp_hpke_boringssl.c
@@ -256,7 +256,7 @@ cleanup:
     if (context != NULL) {
         (*env)->ReleaseByteArrayElements(env, context_array, (jbyte *) context, JNI_ABORT);
     }
-    if (out_array != NULL) {
+    if (out != NULL) {
         int mode = JNI_ABORT;
         if (res == 1) {
             // Copy back changes


### PR DESCRIPTION
Motivation:

Passing a NULL pointer as the elements argument to ReleaseByteArrayElements is undefined behavior per the JNI specification.

Modifications:

Change NULL guard to check the right pointer

Result:

No more UB
