### PR TITLE
HKDF_expand failure might cause UB

### DIFF
--- a/codec-ohttp-hpke-native-boringssl/src/main/c/netty_incubator_codec_ohttp_hpke_boringssl.c
+++ b/codec-ohttp-hpke-native-boringssl/src/main/c/netty_incubator_codec_ohttp_hpke_boringssl.c
@@ -472,7 +472,7 @@ cleanup:
     if (info != NULL) {
         (*env)->ReleaseByteArrayElements(env, info_array, (jbyte *) info, JNI_ABORT);
     }
-    if (out_array != NULL) {
+    if (out != NULL) {
         int mode = JNI_ABORT;
         if (result == 1) {
             // Copy back changes


### PR DESCRIPTION
Motivation:

Passing a NULL pointer as the elements argument to ReleaseByteArrayElements is undefined behavior per the JNI specification.

Modifications:

Change NULL guard to check the right pointer

Result:

No more UB
