### PR TITLE
Fix comment to mention correct class name

### DIFF
--- a/codec-ohttp-hpke-native-boringssl/src/main/c/netty_incubator_codec_ohttp_hpke_boringssl.c
+++ b/codec-ohttp-hpke-native-boringssl/src/main/c/netty_incubator_codec_ohttp_hpke_boringssl.c
@@ -541,7 +541,7 @@ static const jint fixed_method_table_size = sizeof(fixed_method_table) / sizeof(
 // JNI Method Registration Table End
 
 // IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
-//            Quiche to reflect that.
+//            BoringSSL to reflect that.
 static jint netty_incubator_codec_ohttp_hpke_boringssl_JNI_OnLoad(JNIEnv* env, char const* packagePrefix) {
     int ret = JNI_ERR;
     int staticallyRegistered = 0;


### PR DESCRIPTION
Motivation:

We had a copy and paste error in our comment which is confusing.

Modifications:

- Replace Quiche with BoringSSL in the comment

Result:

Cleanup
