### PR TITLE
OHTTP: Add support for XWING

### DIFF
--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSL.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSL.java
@@ -61,6 +61,9 @@ final class BoringSSL {
 
     static final long EVP_hpke_x25519_hkdf_sha256 =
             BoringSSLNativeStaticallyReferencedJniMethods.EVP_hpke_x25519_hkdf_sha256();
+    static final long EVP_hpke_xwing =
+            BoringSSLNativeStaticallyReferencedJniMethods.EVP_hpke_xwing();
+
     static final long EVP_hpke_hkdf_sha256 =
             BoringSSLNativeStaticallyReferencedJniMethods.EVP_hpke_hkdf_sha256();
     static final long EVP_hpke_aes_128_gcm =

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSL.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSL.java
@@ -63,7 +63,6 @@ final class BoringSSL {
             BoringSSLNativeStaticallyReferencedJniMethods.EVP_hpke_x25519_hkdf_sha256();
     static final long EVP_hpke_xwing =
             BoringSSLNativeStaticallyReferencedJniMethods.EVP_hpke_xwing();
-
     static final long EVP_hpke_hkdf_sha256 =
             BoringSSLNativeStaticallyReferencedJniMethods.EVP_hpke_hkdf_sha256();
     static final long EVP_hpke_aes_128_gcm =

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLNativeStaticallyReferencedJniMethods.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLNativeStaticallyReferencedJniMethods.java
@@ -18,7 +18,6 @@ package io.netty.incubator.codec.hpke.boringssl;
 final class BoringSSLNativeStaticallyReferencedJniMethods {
     static native long EVP_hpke_x25519_hkdf_sha256();
     static native long EVP_hpke_xwing();
-
     static native long EVP_hpke_hkdf_sha256();
     static native long EVP_hpke_aes_128_gcm();
     static native long EVP_hpke_aes_256_gcm();

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLNativeStaticallyReferencedJniMethods.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLNativeStaticallyReferencedJniMethods.java
@@ -17,6 +17,8 @@ package io.netty.incubator.codec.hpke.boringssl;
 
 final class BoringSSLNativeStaticallyReferencedJniMethods {
     static native long EVP_hpke_x25519_hkdf_sha256();
+    static native long EVP_hpke_xwing();
+
     static native long EVP_hpke_hkdf_sha256();
     static native long EVP_hpke_aes_128_gcm();
     static native long EVP_hpke_aes_256_gcm();

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLOHttpCryptoProvider.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLOHttpCryptoProvider.java
@@ -89,10 +89,14 @@ public final class BoringSSLOHttpCryptoProvider implements OHttpCryptoProvider {
     }
 
     private static long boringSSLKEM(KEM kem) {
-        if (kem != KEM.X25519_SHA256) {
-            throw new IllegalArgumentException("KEM not supported: " + kem);
+        switch (kem) {
+            case XWING:
+                return BoringSSL.EVP_hpke_xwing;
+            case X25519_SHA256:
+                return BoringSSL.EVP_hpke_x25519_hkdf_sha256;
+            default:
+                throw new IllegalArgumentException("KEM not supported: " + kem);
         }
-        return BoringSSL.EVP_hpke_x25519_hkdf_sha256;
     }
 
     private static long boringSSLHPKEAEAD(AEAD aead) {
@@ -264,7 +268,13 @@ public final class BoringSSLOHttpCryptoProvider implements OHttpCryptoProvider {
 
     @Override
     public boolean isSupported(KEM kem) {
-        return kem == KEM.X25519_SHA256;
+        switch (kem) {
+            case X25519_SHA256:
+            case XWING:
+                return true;
+            default:
+                return false;
+        }
     }
 
     @Override

--- a/codec-ohttp-hpke-native-boringssl/src/main/c/netty_incubator_codec_ohttp_hpke_boringssl.c
+++ b/codec-ohttp-hpke-native-boringssl/src/main/c/netty_incubator_codec_ohttp_hpke_boringssl.c
@@ -502,7 +502,6 @@ cleanup:
 static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "EVP_hpke_x25519_hkdf_sha256", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_x25519_hkdf_sha256 },
   { "EVP_hpke_xwing", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_xwing },
-
   { "EVP_hpke_hkdf_sha256", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_hkdf_sha256 },
   { "EVP_hpke_aes_128_gcm", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_aes_128_gcm },
   { "EVP_hpke_aes_256_gcm", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_aes_256_gcm },

--- a/codec-ohttp-hpke-native-boringssl/src/main/c/netty_incubator_codec_ohttp_hpke_boringssl.c
+++ b/codec-ohttp-hpke-native-boringssl/src/main/c/netty_incubator_codec_ohttp_hpke_boringssl.c
@@ -53,6 +53,10 @@ static jlong netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_x25519_hkdf_sha
     return (jlong) EVP_hpke_x25519_hkdf_sha256();
 }
 
+static jlong netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_xwing(JNIEnv* env, jclass clazz) {
+    return (jlong) EVP_hpke_xwing();
+}
+
 static jlong netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_hkdf_sha256(JNIEnv* env, jclass clazz) {
     return (jlong) EVP_hpke_hkdf_sha256();
 }
@@ -497,6 +501,8 @@ cleanup:
 // JNI Method Registration Table Begin
 static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "EVP_hpke_x25519_hkdf_sha256", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_x25519_hkdf_sha256 },
+  { "EVP_hpke_xwing", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_xwing },
+
   { "EVP_hpke_hkdf_sha256", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_hkdf_sha256 },
   { "EVP_hpke_aes_128_gcm", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_aes_128_gcm },
   { "EVP_hpke_aes_256_gcm", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_aes_256_gcm },

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/KEM.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/KEM.java
@@ -23,7 +23,9 @@ public enum KEM {
     P384_SHA348((short) 17, 97, 97),
     P521_SHA512((short) 18, 133, 133),
     X25519_SHA256((short) 32, 32, 32),
-    X448_SHA512((short) 33, 56, 56);
+    X448_SHA512((short) 33, 56, 56),
+    // See https://datatracker.ietf.org/doc/draft-connolly-cfrg-xwing-kem/
+    XWING((short) 0x647a, 1120, 1216);
 
     public static KEM forId(short id) {
         for (KEM val : values()) {


### PR DESCRIPTION
Motivation:

To support PQC we need to support some KEM like XWING

Modifications:

Support XWING in our native implementation using BoringSSL

Result:

Be able to use XWING for OHTTP
