### PR TITLE
OHTTP: Allow to configure maxInitialLineSize

### DIFF
--- a/codec-bhttp/src/main/java/io/netty/incubator/codec/bhttp/BinaryHttpParser.java
+++ b/codec-bhttp/src/main/java/io/netty/incubator/codec/bhttp/BinaryHttpParser.java
@@ -136,7 +136,7 @@ public final class BinaryHttpParser {
      * @param maxFieldSectionSize   the maximum size of the field-section (in bytes)
      */
     public BinaryHttpParser(int maxFieldSectionSize) {
-        this(256, maxFieldSectionSize);
+        this(1024, maxFieldSectionSize);
     }
 
     /**

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpClientCodec.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpClientCodec.java
@@ -79,6 +79,7 @@ public final class OHttpClientCodec extends MessageToMessageCodec<HttpObject, Ht
 
     private final OHttpCryptoProvider provider;
     private final Function<HttpRequest, EncapsulationParameters> encapsulationFunc;
+    private final int maxInitialLineSize;
     private final int maxFieldSectionSize;
 
     private ByteBuf cumulationBuffer = Unpooled.EMPTY_BUFFER;
@@ -110,6 +111,7 @@ public final class OHttpClientCodec extends MessageToMessageCodec<HttpObject, Ht
         this.provider = requireNonNull(builder.getProvider(), "builder.getProvider()");
         this.encapsulationFunc = requireNonNull(builder.getEncapsulationFunction(),
                 "builder.getEncapsulationFunction()");
+        maxInitialLineSize = builder.getMaxInitialLineSize();
         maxFieldSectionSize = builder.getMaxFieldSectionSize();
     }
 
@@ -272,7 +274,8 @@ public final class OHttpClientCodec extends MessageToMessageCodec<HttpObject, Ht
                 EncapsulationParameters encapsulation = encapsulationFunc.apply(innerRequest);
                 if (encapsulation != null) {
                     OHttpClientRequestResponseContext oHttpContext =
-                            new OHttpClientRequestResponseContext(encapsulation, provider, maxFieldSectionSize);
+                            new OHttpClientRequestResponseContext(encapsulation, provider,
+                                    maxInitialLineSize, maxFieldSectionSize);
                     HttpHeaders outerHeaders = encapsulation.outerRequestHeaders();
                     DefaultHttpRequest outerRequest = new DefaultHttpRequest(
                             innerRequest.protocolVersion(),
@@ -340,8 +343,9 @@ public final class OHttpClientCodec extends MessageToMessageCodec<HttpObject, Ht
         private final OHttpCryptoSender sender;
 
         OHttpClientRequestResponseContext(
-                EncapsulationParameters parameters, OHttpCryptoProvider provider, int maxFieldSectionSize) {
-            super(parameters.version(), maxFieldSectionSize);
+                EncapsulationParameters parameters, OHttpCryptoProvider provider, int maxInitialLineSize,
+                int maxFieldSectionSize) {
+            super(parameters.version(), maxInitialLineSize, maxFieldSectionSize);
             this.sender = OHttpCryptoSender.newBuilder()
                     .setOHttpCryptoProvider(provider)
                     .setConfiguration(parameters.version())

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCodecBuilder.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpCodecBuilder.java
@@ -17,6 +17,7 @@ package io.netty.incubator.codec.ohttp;
 
 import io.netty.channel.ChannelHandler;
 import io.netty.incubator.codec.hpke.OHttpCryptoProvider;
+import io.netty.util.internal.ObjectUtil;
 
 import static java.util.Objects.requireNonNull;
 
@@ -26,9 +27,11 @@ import static java.util.Objects.requireNonNull;
  */
 public abstract class OHttpCodecBuilder<B extends OHttpCodecBuilder<B>> implements Cloneable {
     static final int DEFAULT_MAX_FIELD_SECTION_SIZE = 8 * 1024;
+    static final int DEFAULT_MAX_INITIAL_LINE_SIZE = 1024;
 
     private OHttpCryptoProvider provider;
     private int maxFieldSectionSize = DEFAULT_MAX_FIELD_SECTION_SIZE;
+    private int maxInitialLineSize = DEFAULT_MAX_INITIAL_LINE_SIZE;
 
     /**
      * Package-private constructor, to prevent integrators from extending this class.
@@ -56,6 +59,24 @@ public abstract class OHttpCodecBuilder<B extends OHttpCodecBuilder<B>> implemen
      */
     public final B setProvider(OHttpCryptoProvider provider) {
         this.provider = requireNonNull(provider, "provider");
+        return self();
+    }
+
+    /**
+     * The maximum size of the initial line (in bytes).
+     * @return The max initial line size.
+     */
+    public final int getMaxInitialLineSize() {
+        return maxInitialLineSize;
+    }
+
+    /**
+     * Set the maximum size of the initial line (in bytes).
+     * @param maxInitialLineSize The max initial line size, in bytes. Must be positive.
+     * @return this builder.
+     */
+    public final B setMaxInitialLineSize(int maxInitialLineSize) {
+        this.maxInitialLineSize = ObjectUtil.checkPositive(maxInitialLineSize, "maxInitialLineSize");
         return self();
     }
 

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpRequestResponseContext.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpRequestResponseContext.java
@@ -37,11 +37,13 @@ import static io.netty.handler.codec.ByteToMessageDecoder.MERGE_CUMULATOR;
 abstract class OHttpRequestResponseContext {
     private final OHttpVersion version;
     private final ContentEncoder contentEncoder;
+    private final int maxInitialLineSize;
     private final int maxFieldSectionSize;
     private ContentDecoder decoder;
 
-    OHttpRequestResponseContext(OHttpVersion version, int maxFieldSectionSize) {
+    OHttpRequestResponseContext(OHttpVersion version, int maxInitialLineSize, int maxFieldSectionSize) {
         this.version = version;
+        this.maxInitialLineSize = maxInitialLineSize; // Assign before creating ContentDecoder!
         this.maxFieldSectionSize = maxFieldSectionSize; // Assign before creating ContentDecoder!
         contentEncoder = new ContentEncoder();
         decoder = new ContentDecoder();
@@ -180,7 +182,7 @@ abstract class OHttpRequestResponseContext {
     private final class ContentDecoder implements OHttpChunkFramer.Decoder {
 
         // Allow up to 8kb for the field-section.
-        private final BinaryHttpParser binaryHttpParser = new BinaryHttpParser(maxFieldSectionSize);
+        private final BinaryHttpParser binaryHttpParser = new BinaryHttpParser(maxInitialLineSize, maxFieldSectionSize);
 
         // Cumulation buffer with plaintext binary HTTP bytes, which are coming from decrypted type 0 chunks.
         private ByteBuf binaryHttpCumulation = Unpooled.EMPTY_BUFFER;

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
@@ -60,6 +60,7 @@ public class OHttpServerCodec extends MessageToMessageCodec<HttpObject, HttpObje
 
     private final OHttpCryptoProvider provider;
     private final OHttpServerKeys serverKeys;
+    private final int maxInitialLineSize;
     private final int maxFieldSectionSize;
 
     private HttpRequest request;
@@ -83,6 +84,7 @@ public class OHttpServerCodec extends MessageToMessageCodec<HttpObject, HttpObje
     OHttpServerCodec(OHttpServerCodecBuilder builder) {
         this.provider = requireNonNull(builder.getProvider(), "builder.getProvider()");
         this.serverKeys = requireNonNull(builder.getServerKeys(), "builder.getServerKeys()");
+        maxInitialLineSize = builder.getMaxInitialLineSize();
         maxFieldSectionSize = builder.getMaxFieldSectionSize();
     }
 
@@ -149,7 +151,7 @@ public class OHttpServerCodec extends MessageToMessageCodec<HttpObject, HttpObje
                     // Keep a copy of the request, which will be used to generate the response.
                     request = new DefaultHttpRequest(req.protocolVersion(), req.method(), req.uri(), req.headers());
                     oHttpContext = new OHttpServerRequestResponseContext(
-                            version, provider, serverKeys, maxFieldSectionSize);
+                            version, provider, serverKeys, maxInitialLineSize, maxFieldSectionSize);
                 } else {
                     sentResponse = true;
                     FullHttpResponse response = new DefaultFullHttpResponse(
@@ -308,8 +310,9 @@ public class OHttpServerCodec extends MessageToMessageCodec<HttpObject, HttpObje
         private boolean sendLastHttpContent;
 
         OHttpServerRequestResponseContext(
-                OHttpVersion version, OHttpCryptoProvider provider, OHttpServerKeys keys, int maxFieldSectionSize) {
-            super(version, maxFieldSectionSize);
+                OHttpVersion version, OHttpCryptoProvider provider, OHttpServerKeys keys, int maxInitialLineSize,
+                int maxFieldSectionSize) {
+            super(version, maxInitialLineSize, maxFieldSectionSize);
             this.provider = provider;
             this.keys = keys;
         }


### PR DESCRIPTION
Motivation:

c5169de8814dbe730280fd793a0428a844e9045c introduced a limit for the inital line size but missed to add a way to change it when BHTTP is used via OHTTP.

Modifications:

- Allow to configure the maxInitialLineSize via the OHTTP*CodecBuilder
- Change default to 1024

Result:

Be able to configure the inital line size
