### PR TITLE
OHTTP: Expose a new constructor so sub-classes can configure everything

### DIFF
--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
@@ -87,7 +87,6 @@ public class OHttpServerCodec extends MessageToMessageCodec<HttpObject, HttpObje
                 builder.getMaxInitialLineSize(), builder.getMaxFieldSectionSize());
     }
 
-
     /**
      * Create a new instance with the given configuration.
      */
@@ -96,7 +95,12 @@ public class OHttpServerCodec extends MessageToMessageCodec<HttpObject, HttpObje
         this.provider = requireNonNull(provider, "provider");
         this.serverKeys = requireNonNull(serverKeys, "serverKeys");
         this.maxInitialLineSize = ObjectUtil.checkPositive(maxInitialLineSize, "maxInitialLineSize");
-        this.maxFieldSectionSize = ObjectUtil.checkPositive(maxFieldSectionSize, "maxFieldSectionSize");
+        maxFieldSectionSize = ObjectUtil.checkPositive(maxFieldSectionSize, "maxFieldSectionSize");
+        if (maxFieldSectionSize > (Integer.MAX_VALUE >> 1)) {
+            throw new IllegalArgumentException("Max field section size cannot be greater than " +
+                    (Integer.MAX_VALUE >> 1));
+        }
+        this.maxFieldSectionSize = maxFieldSectionSize;
     }
 
     /**

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpServerCodec.java
@@ -43,6 +43,7 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.incubator.codec.hpke.OHttpCryptoProvider;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.List;
 
@@ -82,10 +83,20 @@ public class OHttpServerCodec extends MessageToMessageCodec<HttpObject, HttpObje
      * @param builder The codec configuration to use.
      */
     OHttpServerCodec(OHttpServerCodecBuilder builder) {
-        this.provider = requireNonNull(builder.getProvider(), "builder.getProvider()");
-        this.serverKeys = requireNonNull(builder.getServerKeys(), "builder.getServerKeys()");
-        maxInitialLineSize = builder.getMaxInitialLineSize();
-        maxFieldSectionSize = builder.getMaxFieldSectionSize();
+        this(builder.getProvider(), builder.getServerKeys(),
+                builder.getMaxInitialLineSize(), builder.getMaxFieldSectionSize());
+    }
+
+
+    /**
+     * Create a new instance with the given configuration.
+     */
+    protected OHttpServerCodec(OHttpCryptoProvider provider, OHttpServerKeys serverKeys,
+                               int maxInitialLineSize, int maxFieldSectionSize) {
+        this.provider = requireNonNull(provider, "provider");
+        this.serverKeys = requireNonNull(serverKeys, "serverKeys");
+        this.maxInitialLineSize = ObjectUtil.checkPositive(maxInitialLineSize, "maxInitialLineSize");
+        this.maxFieldSectionSize = ObjectUtil.checkPositive(maxFieldSectionSize, "maxFieldSectionSize");
     }
 
     /**


### PR DESCRIPTION
Motivation:

We need to allow sub-classes of OHttpServerCodec to configure everything

Modifications:

- Add new protected constructor

Result:

Be able to subclass