### PR TITLE
Fix verification of public key when creating OHttpKey

### DIFF
--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/KEM.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/KEM.java
@@ -25,7 +25,7 @@ public enum KEM {
     X25519_SHA256((short) 32, 32, 32),
     X448_SHA512((short) 33, 56, 56),
     // See https://datatracker.ietf.org/doc/draft-connolly-cfrg-xwing-kem/
-    XWING((short) 0x647a, 1120, 32);
+    XWING((short) 0x647a, 1120, 1216);
 
     public static KEM forId(short id) {
         for (KEM val : values()) {

--- a/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpKey.java
+++ b/codec-ohttp/src/main/java/io/netty/incubator/codec/ohttp/OHttpKey.java
@@ -186,7 +186,7 @@ public abstract class OHttpKey {
 
             requireNonNull(keyPair, "keyPair");
 
-            byte[] encoded = keyPair.privateParameters().encoded();
+            byte[] encoded = keyPair.publicParameters().encoded();
             if (encoded != null && encoded.length != kem.npk()) {
                 throw new CryptoException("Invalid public key, pkEncoded.length(" + encoded.length +
                         ") does not match Npk(" + kem.npk() + ") from KEM: " + kem);


### PR DESCRIPTION
Motivation:

We used the private key and not the public key when verify the npk. Due of this we also introduced a bug in 1a0ce6a6e0584dd00e9c57a02c0d549594f05925 for XWING

Modifications:

- Verify the correct key
- Revert change related to XWING which was incorrect

Result:

Correctly verify public key