### PR TITLE
Correctly support P256_SHA256, P384_SHA348, P521_SHA512 when using BouncyCastle

### DIFF
--- a/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleAsymmetricKeyParameter.java
+++ b/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleAsymmetricKeyParameter.java
@@ -16,6 +16,8 @@
 package io.netty.incubator.codec.hpke.bouncycastle;
 
 import io.netty.incubator.codec.hpke.AsymmetricKeyParameter;
+import org.bouncycastle.crypto.params.ECPrivateKeyParameters;
+import org.bouncycastle.crypto.params.ECPublicKeyParameters;
 import org.bouncycastle.crypto.params.X25519PrivateKeyParameters;
 import org.bouncycastle.crypto.params.X25519PublicKeyParameters;
 import org.bouncycastle.crypto.params.X448PrivateKeyParameters;
@@ -42,11 +44,30 @@ final class BouncyCastleAsymmetricKeyParameter implements AsymmetricKeyParameter
         if (param instanceof X448PublicKeyParameters) {
             return ((X448PublicKeyParameters) param).getEncoded();
         }
+        if (param instanceof ECPublicKeyParameters) {
+            return ((ECPublicKeyParameters) param).getQ().getEncoded(false);
+        }
         if (param instanceof X25519PrivateKeyParameters) {
             return ((X25519PrivateKeyParameters) param).getEncoded();
         }
         if (param instanceof X448PrivateKeyParameters) {
             return ((X448PrivateKeyParameters) param).getEncoded();
+        }
+        if (param instanceof ECPrivateKeyParameters) {
+            ECPrivateKeyParameters privateKey = (ECPrivateKeyParameters) param;
+            byte[] rawD = privateKey.getD().toByteArray();
+            //  Removing any extra leading 0x00 signs from BigInteger if needed.
+            switch (rawD.length) {
+                case 33: // P256_SHA256
+                case 49: // P384_SHA348
+                case 65: // P521_SHA512
+                    if (rawD[0] == 0) {
+                        return java.util.Arrays.copyOfRange(rawD, 1, rawD.length);
+                    }
+                    // fall-through
+                default:
+                    return rawD;
+            }
         }
         return null;
     }

--- a/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleOHttpCryptoProvider.java
+++ b/codec-ohttp-hpke-bouncycastle/src/main/java/io/netty/incubator/codec/hpke/bouncycastle/BouncyCastleOHttpCryptoProvider.java
@@ -25,7 +25,9 @@ import io.netty.incubator.codec.hpke.KDF;
 import io.netty.incubator.codec.hpke.KEM;
 import io.netty.incubator.codec.hpke.OHttpCryptoProvider;
 import org.bouncycastle.asn1.nist.NISTNamedCurves;
+import org.bouncycastle.crypto.generators.ECKeyPairGenerator;
 import org.bouncycastle.crypto.params.ECDomainParameters;
+import org.bouncycastle.crypto.params.ECKeyGenerationParameters;
 import org.bouncycastle.crypto.params.ECPrivateKeyParameters;
 import org.bouncycastle.crypto.params.ECPublicKeyParameters;
 import org.bouncycastle.crypto.params.X25519PrivateKeyParameters;
@@ -177,6 +179,19 @@ public final class BouncyCastleOHttpCryptoProvider implements OHttpCryptoProvide
                 X448PrivateKeyParameters x448PrivateKey = new X448PrivateKeyParameters(random);
                 return new org.bouncycastle.crypto.AsymmetricCipherKeyPair(
                         x448PrivateKey.generatePublicKey(), x448PrivateKey);
+            case P256_SHA256:
+            case P384_SHA348:
+            case P521_SHA512:
+                ECDomainParameters parameters = ecDomainParameters(kem);
+
+                // Initialize Key Generator
+                ECKeyGenerationParameters keyParams = new ECKeyGenerationParameters(parameters, random);
+
+                ECKeyPairGenerator generator = new ECKeyPairGenerator();
+                generator.init(keyParams);
+
+                // Generate the key pair
+                return generator.generateKeyPair();
             default:
                 throw new UnsupportedOperationException("Can't generate random key for kem: " + kem);
         }

--- a/codec-ohttp/src/test/java/io/netty/incubator/codec/ohttp/OHttpCodecsTest.java
+++ b/codec-ohttp/src/test/java/io/netty/incubator/codec/ohttp/OHttpCodecsTest.java
@@ -84,7 +84,7 @@ public class OHttpCodecsTest {
             List<Arguments> arguments = new ArrayList<>();
             for (int i = 0; i < 2; i++) {
                 boolean trailers = i == 0;
-                for (KEM kem: new KEM[] { KEM.X25519_SHA256, KEM.XWING }) {
+                for (KEM kem: KEM.values()) {
                     arguments.add(Arguments.of(
                             OHttpVersionDraft.INSTANCE, BouncyCastleOHttpCryptoProvider.INSTANCE,
                             BouncyCastleOHttpCryptoProvider.INSTANCE, kem, trailers));


### PR DESCRIPTION
Motivation:

We not really supported P256_SHA256, P384_SHA348, P521_SHA512 correctly when using BouncyCastle as we missed some implementation for the AsymmentricKeyParameter and also did not correctly support generating a random key pair

Modifications:

- Add missing implementation
- Adjust unit tests to also tests these KEMs when supported by the provider implementation

Result:

Correctly support P256_SHA256, P384_SHA348, P521_SHA512 when using BouncyCastle
