### PR TITLE
BoringSSL: Add support for MLKEM768 and MLKEM1024

### DIFF
--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSL.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSL.java
@@ -63,6 +63,10 @@ final class BoringSSL {
             BoringSSLNativeStaticallyReferencedJniMethods.EVP_hpke_x25519_hkdf_sha256();
     static final long EVP_hpke_xwing =
             BoringSSLNativeStaticallyReferencedJniMethods.EVP_hpke_xwing();
+    static final long EVP_hpke_mlkem768 =
+            BoringSSLNativeStaticallyReferencedJniMethods.EVP_hpke_mlkem768();
+    static final long EVP_hpke_mlkem1024 =
+            BoringSSLNativeStaticallyReferencedJniMethods.EVP_hpke_mlkem1024();
     static final long EVP_hpke_hkdf_sha256 =
             BoringSSLNativeStaticallyReferencedJniMethods.EVP_hpke_hkdf_sha256();
     static final long EVP_hpke_aes_128_gcm =

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLNativeStaticallyReferencedJniMethods.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLNativeStaticallyReferencedJniMethods.java
@@ -18,6 +18,9 @@ package io.netty.incubator.codec.hpke.boringssl;
 final class BoringSSLNativeStaticallyReferencedJniMethods {
     static native long EVP_hpke_x25519_hkdf_sha256();
     static native long EVP_hpke_xwing();
+    static native long EVP_hpke_mlkem768();
+    static native long EVP_hpke_mlkem1024();
+
     static native long EVP_hpke_hkdf_sha256();
     static native long EVP_hpke_aes_128_gcm();
     static native long EVP_hpke_aes_256_gcm();

--- a/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLOHttpCryptoProvider.java
+++ b/codec-ohttp-hpke-classes-boringssl/src/main/java/io/netty/incubator/codec/hpke/boringssl/BoringSSLOHttpCryptoProvider.java
@@ -92,6 +92,10 @@ public final class BoringSSLOHttpCryptoProvider implements OHttpCryptoProvider {
         switch (kem) {
             case XWING:
                 return BoringSSL.EVP_hpke_xwing;
+            case MLKEM786:
+                return BoringSSL.EVP_hpke_mlkem768;
+            case MLKEM1024:
+                return BoringSSL.EVP_hpke_mlkem1024;
             case X25519_SHA256:
                 return BoringSSL.EVP_hpke_x25519_hkdf_sha256;
             default:
@@ -271,6 +275,8 @@ public final class BoringSSLOHttpCryptoProvider implements OHttpCryptoProvider {
         switch (kem) {
             case X25519_SHA256:
             case XWING:
+            case MLKEM786:
+            case MLKEM1024:
                 return true;
             default:
                 return false;

--- a/codec-ohttp-hpke-native-boringssl/pom.xml
+++ b/codec-ohttp-hpke-native-boringssl/pom.xml
@@ -46,9 +46,8 @@
         <boringsslHomeBuildDir>${boringsslHomeDir}/build</boringsslHomeBuildDir>
         <boringsslHomeIncludeDir>${boringsslHomeDir}/include</boringsslHomeIncludeDir>
         <boringsslRepository>https://boringssl.googlesource.com/boringssl</boringsslRepository>
-        <!-- Lets use what we use in netty-tcnative-boringssl-static -->
         <boringsslBranch>main</boringsslBranch>
-        <boringsslCommitSha>0226f30467f540a3f62ef48d453f93927da199b6</boringsslCommitSha>
+        <boringsslCommitSha>5ac7567c234514157a504ff3fbedc0f5eddbf678</boringsslCommitSha>
 
         <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
         <templateDir>${project.build.directory}/template</templateDir>

--- a/codec-ohttp-hpke-native-boringssl/src/main/c/netty_incubator_codec_ohttp_hpke_boringssl.c
+++ b/codec-ohttp-hpke-native-boringssl/src/main/c/netty_incubator_codec_ohttp_hpke_boringssl.c
@@ -57,6 +57,14 @@ static jlong netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_xwing(JNIEnv* e
     return (jlong) EVP_hpke_xwing();
 }
 
+static jlong netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_mlkem768(JNIEnv* env, jclass clazz) {
+    return (jlong) EVP_hpke_mlkem768();
+}
+
+static jlong netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_mlkem1024(JNIEnv* env, jclass clazz) {
+    return (jlong) EVP_hpke_mlkem1024();
+}
+
 static jlong netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_hkdf_sha256(JNIEnv* env, jclass clazz) {
     return (jlong) EVP_hpke_hkdf_sha256();
 }
@@ -502,6 +510,9 @@ cleanup:
 static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "EVP_hpke_x25519_hkdf_sha256", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_x25519_hkdf_sha256 },
   { "EVP_hpke_xwing", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_xwing },
+  { "EVP_hpke_mlkem768", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_mlkem768 },
+  { "EVP_hpke_mlkem1024", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_mlkem1024 },
+
   { "EVP_hpke_hkdf_sha256", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_hkdf_sha256 },
   { "EVP_hpke_aes_128_gcm", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_aes_128_gcm },
   { "EVP_hpke_aes_256_gcm", "()J", (void *) netty_incubator_codec_ohttp_hpke_boringssl_EVP_hpke_aes_256_gcm },

--- a/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/KEM.java
+++ b/codec-ohttp-hpke/src/main/java/io/netty/incubator/codec/hpke/KEM.java
@@ -25,7 +25,10 @@ public enum KEM {
     X25519_SHA256((short) 32, 32, 32),
     X448_SHA512((short) 33, 56, 56),
     // See https://datatracker.ietf.org/doc/draft-connolly-cfrg-xwing-kem/
-    XWING((short) 0x647a, 1120, 1216);
+    XWING((short) 0x647a, 1120, 1216),
+    // https://datatracker.ietf.org/doc/html/draft-ietf-hpke-pq-05#ml-kem-iana-table
+    MLKEM786((short) 0x0041, 1088, 1184),
+    MLKEM1024((short) 0x0042, 1568, 1568);
 
     public static KEM forId(short id) {
         for (KEM val : values()) {


### PR DESCRIPTION
Motivation:

BoringSSL supports MLKEM768 and MLKEM1024 these days so we can also support it

Modifications:

- Add MLKEM768 and MLKEM1024 to our KEM enum
- Add support for these to our BoringSSL based implementation
- Update BoringSSL to the latest sha so it supports MLKEM*

Result:

Support more PQC KEMs when using BoringSSL
